### PR TITLE
Minor cleanup, pass only CacheAndSeed to searchSeedBi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,18 +34,18 @@ BOWTIE_SHARED_MEM :=
 #
 # Recommended g++ flags
 # CPU-only
-#CXX := g++
-#CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP -g
+CXX := g++
+CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP -g
 
 #
 # Recommended amdclang++ flags
-CXX := amdclang++
+#CXX := amdclang++
 
 # CPU-only
 #CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP -g
 #
 # GPU-enabled
-CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
+#CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
 
 #
 # NVIDIA HPC SDK flags options

--- a/Makefile
+++ b/Makefile
@@ -34,18 +34,18 @@ BOWTIE_SHARED_MEM :=
 #
 # Recommended g++ flags
 # CPU-only
-CXX := g++
-CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP
+#CXX := g++
+#CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP -g
 
 #
 # Recommended amdclang++ flags
-#CXX := amdclang++
+CXX := amdclang++
 
 # CPU-only
-#CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP
+#CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP -g
 #
 # GPU-enabled
-#CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
+CXXFLAGS += -std=c++17 -DFORCE_ALL_OMP -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
 
 #
 # NVIDIA HPC SDK flags options

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -126,20 +126,10 @@ public:
 
 	// create an empty bwt
 	// and constratins from seed, for initial searchSeedBi invocation
-	SeedAlignerSearchParams(
-		const char *   _seq,             // sequence of the local seed alignment cache
-		const uint32_t _seq_len          // and its length
-	)
-	: cs(_seq,_seq_len)
-	{}
-
-	// create an empty bwt
-	// and constratins from seed, for initial searchSeedBi invocation
 	SeedAlignerSearchParams()
-	: cs()
 	{}
 
-	SeedAlignerSearchParams& operator=(const SeedAlignerSearchParams& other) = default;
+	SeedAlignerSearchParams& operator=(const SeedAlignerSearchParams& other) = delete;
 
 	void reset(
 		const SeedResults* sr,

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -305,7 +305,7 @@ SeedAligner::instantiateSeq(
 	// If fw is false, we take characters starting at the 3' end of the
 	// reverse complement of the read.
 	const int rdlen = read.length();
-	auto& readpat = fw ? read.patFw : read.patRc;
+	//auto& readpat = fw ? read.patFw : read.patRc;
 	int rel_depth = fw ? depth : (rdlen - depth - len);
 	return rel_depth;;
 }

--- a/aligner_seed.cpp
+++ b/aligner_seed.cpp
@@ -108,6 +108,7 @@ public:
 			if (abs(_seed.n_steps)>127) {printf("Unexpected n_seed_steps %i\n",int(_seed.n_steps)); throw 1;}
 #endif
 			n_seed_steps = _seed.n_steps;
+			//if (n_seed_steps!=seq_len) fprintf(stderr, "n_seed_steps!=seq_len %i,%i\n",int(n_seed_steps),int(seq_len));
 		}
 
 		CacheAndSeed(CacheAndSeed &other) = default;
@@ -557,6 +558,18 @@ MultiSeedAligner::~MultiSeedAligner() {
 	delete[] _als;
 }
 
+// just make sure the buffers are large enough
+void MultiSeedAligner::reserveBuffersFixed(size_t buf_total_size) {
+	if (_bufVec_size<buf_total_size) {
+		// need bigger buffers
+		if (_dataVec!=NULL) delete[] _dataVec;
+		if (_paramVec!=NULL) delete[] _paramVec;
+		_paramVec = new SeedAlignerSearchParams[buf_total_size];
+		_dataVec = new SeedAlignerSearchData[buf_total_size];
+		_bufVec_size = buf_total_size;
+	}
+}
+
 // Update buffer, based on content of _srs
 void MultiSeedAligner::reserveBuffers()
 {
@@ -571,14 +584,7 @@ void MultiSeedAligner::reserveBuffers()
 		buf_total_size+=_als[i].computeValidInstantiatedSeeds(_srs.getSR(i));
 	}
 
-	if (_bufVec_size<buf_total_size) {
-		// need bigger buffers
-		if (_dataVec!=NULL) delete[] _dataVec;
-		if (_paramVec!=NULL) delete[] _paramVec;
-		_paramVec = new SeedAlignerSearchParams[buf_total_size];
-		_dataVec = new SeedAlignerSearchData[buf_total_size];
-		_bufVec_size = buf_total_size;
-	}
+	reserveBuffersFixed(buf_total_size);
 
 	// now update buffers in SearchResults
 	buf_total_size = 0;

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1333,6 +1333,7 @@ public:
 };
 
 class SeedAlignerSearchState;
+class CacheAndSeed;
 class SeedAlignerSearchParams;
 class SeedAlignerSearchData;
 
@@ -1356,8 +1357,10 @@ public:
 
 	// Set buffers needed by searchAllSeeds
 	void setBufs(
+		CacheAndSeed*            seedVec,
 		SeedAlignerSearchParams* paramVec,
 		SeedAlignerSearchData*   dataVec) {
+		seedVec_ = seedVec;
 		paramVec_ = paramVec;
 		dataVec_  = dataVec;
 	}
@@ -1416,7 +1419,7 @@ public:
 		        const Ebwt* ebwt,         // forward index (BWT)
         		uint64_t& bwops_,         // Burrows-Wheeler operations
 			const uint8_t nparams,    // must be leq SS_SIZE
-			const SeedAlignerSearchParams paramVec[],
+			const CacheAndSeed            seedVec[],
 			SeedAlignerSearchData         dataVec[]);
 
 protected:
@@ -1430,6 +1433,7 @@ protected:
  	**/
 	static constexpr uint8_t ibatch_size = 8;
 
+	CacheAndSeed*            seedVec_;       // not owned
 	SeedAlignerSearchParams* paramVec_;      // not owned
 	SeedAlignerSearchData*   dataVec_;       // not owned
 	uint32_t                 seedsearches_;   // valid elements in the above buffers
@@ -1524,6 +1528,7 @@ private:
 
 	const int                _ftabLen;
 
+	CacheAndSeed*            _seedVec;       // array of _bufVec_size
 	SeedAlignerSearchParams* _paramVec;      // array of _bufVec_size
 	SeedAlignerSearchData*   _dataVec;       // array of _bufVec_size
 

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1466,6 +1466,9 @@ public:
 	// Update buffers, based on content of _srs
 	void reserveBuffers();
 
+	// Allocate buffers of fixed size
+	void reserveBuffersFixed(size_t bufVec_size);
+
 	/**
 	 * Iterate through the seeds that cover the read and initiate a
 	 * search for each seed.

--- a/aligner_seed.h
+++ b/aligner_seed.h
@@ -1509,12 +1509,11 @@ public:
 protected:
 
 	static uint16_t extend(
-		const SeedResults& sh, // seed hits to extend into full alignments
 		const Ebwt& ebwtFw,    // Forward Bowtie index
 		TIndexOffU topf,       // top in fw index
 		TIndexOffU botf,       // bot in fw index
-		bool fw,              // seed orientation
-		size_t off,           // seed offset from 5' end
+		const char* seq,       // pointer to the end of the sequence
+		uint8_t     lim,       // how many chars do I have
 		size_t& nlex);         // # positions we can extend to left w/o edit
 
 private:

--- a/aligner_sw.cpp
+++ b/aligner_sw.cpp
@@ -269,7 +269,6 @@ bool SwAligner::nextAlignment(
 	const size_t candsz = btncand_.size();
 	size_t SQ = dpRows() >> 4;
 	if(SQ == 0) SQ = 1;
-	size_t rdlen = rdlen_;
 	// assert(!checkpointed)
 	while(cural_ < candsz) {
 		// Doing 'continue' anywhere in here simply causes us to move on to the

--- a/aligner_sw_driver.cpp
+++ b/aligner_sw_driver.cpp
@@ -358,10 +358,10 @@ int SwDriver::extendSeeds(
 			// If the range is small, investigate all elements now.  If the
 			// range is large, just investigate one and move on - we might come
 			// back to this range later.
-			size_t riter = 0;
+			//size_t riter = 0;
 			while(!sdrnd.rands_[i].done() && (first || is_small )) {
 				assert(!gws_[i].done());
-				riter++;
+				//riter++;
 				if(minsc == perfectScore) {
 					return EXTEND_PERFECT_SCORE;
 				}
@@ -525,7 +525,6 @@ int SwDriver::extendSeeds(
 						prm.nDpFail = 0;
 					}
 				}
-				bool firstInner = true;
 				while(true) {
 					assert(found);
 					SwResult *res = NULL;
@@ -543,7 +542,6 @@ int SwDriver::extendSeeds(
 						res = &resGap_;
 					}
 					assert(res != NULL);
-					firstInner = false;
 					Interval refival(tidx, 0, fw, tlen);
 					assert_gt(res->alres.refExtent(), 0);
 					if(reportOverhangs &&
@@ -831,7 +829,7 @@ int SwDriver::extendSeedsPaired(
 	size_t nelt = 0, neltLeft = 0;
 	const size_t rows = rdlen;
 	const size_t orows  = ordlen;
-	size_t eltsDone = 0;
+	//size_t eltsDone = 0;
 	while(true) {
 		if(eeMode) {
 			if(firstEe) {
@@ -950,7 +948,7 @@ int SwDriver::extendSeedsPaired(
 					satpos_[i].sat.offs,
 					satpos_[i].sat.fmap);
 				gws_[i].advanceElement((TIndexOffU)elt, ebwtFw, ref, sa, gwstate_, wr, prm);
-				eltsDone++;
+				//eltsDone++;
 				assert_gt(neltLeft, 0);
 				neltLeft--;
 				assert_neq(OFF_MASK, wr.toff);

--- a/aligner_sw_driver.h
+++ b/aligner_sw_driver.h
@@ -359,7 +359,7 @@ public:
 
 	// Allow move operator
 	SwDriver(SwDriver&& other) = default;
-	SwDriver& operator=(SwDriver&& other) noexcept = default;
+	SwDriver& operator=(SwDriver&& other) noexcept = delete;
 
 	// but not copy
 	SwDriver(const SwDriver& other) = delete;

--- a/aln_sink.h
+++ b/aln_sink.h
@@ -1027,7 +1027,7 @@ public:
 
 	// allow move operators
 	AlnSinkWrap(AlnSinkWrap&& o) = default;
-	AlnSinkWrap& operator=(AlnSinkWrap&& o) noexcept = default;
+	AlnSinkWrap& operator=(AlnSinkWrap&& o) noexcept = delete;
 
 	// but not copy operators
 	AlnSinkWrap(const AlnSinkWrap& o) = delete;

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -1960,8 +1960,8 @@ public:
 	SwDriverBT2()
 	: SwDriver() {}
 
-	SwDriverBT2(SwDriverBT2&& other) = default;
-	SwDriverBT2& operator=(SwDriverBT2&& other) noexcept = default;
+	SwDriverBT2(SwDriverBT2&& other) = delete;
+	SwDriverBT2& operator=(SwDriverBT2&& other) noexcept = delete;
 
 	SwDriverBT2(const SwDriverBT2& other) = delete;
 	SwDriverBT2& operator=(const SwDriverBT2& other) = delete;
@@ -2172,10 +2172,10 @@ public:
 	, rnd()
 	{}
 
-	msWorkerObjs(msWorkerObjs&& o) = default;
+	msWorkerObjs(msWorkerObjs&& o) = delete;
 	msWorkerObjs(const msWorkerObjs& o) = delete;
 
-	msWorkerObjs &operator=(msWorkerObjs&& o) noexcept = default;
+	msWorkerObjs &operator=(msWorkerObjs&& o) noexcept = delete;
 	msWorkerObjs &operator=(const msWorkerObjs& o) noexcept = delete;
 
 	void set_alloc(BTAllocator *alloc, bool propagate_alloc=true)

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -2395,7 +2395,7 @@ static void multiseedSearchWorker() {
 		}
 
 		// Used by thread with threadid == 1 to measure time elapsed
-		time_t iTime = time(0);
+		// time_t iTime = time(0);
 
 		// Keep track of whether last search was exhaustive
 		bool *exhaustive = new(worker_alloc.allocate(num_parallel_tasks,sizeof(bool))) bool[num_parallel_tasks];
@@ -2692,7 +2692,6 @@ static void multiseedSearchWorker() {
 				const uint32_t mate = nb*reads_per_batch + ib;
 				if (mate_idx[mate]>=0 ) { // !done[mate]
 					msWorkerObjs& msobj = g_msobjs[mate];
-					const uint16_t interval = intervals[mate];
 					const SeedResults& sh = psrs->getSR(mate);
 					AlignmentCacheInterface ca = als.getCacheInterface(mate); // copy OK, just a few references
 
@@ -2966,7 +2965,7 @@ static void multiseedSearchWorkerPaired(const size_t num_parallel_tasks) {
 		PerReadMetrics prm;
 
 		// Used by thread with threadid == 1 to measure time elapsed
-		time_t iTime = time(0);
+		// time_t iTime = time(0);
 
 		// Keep track of whether last search was exhaustive for mates 1 and 2
 		bool exhaustive[2] = { false, false };


### PR DESCRIPTION
searchSeedBi does not not need the whole SeedAlignerSearchParams structure,
avoid requiring it.
Plus other minor cleanup.