### PR TITLE
2 aligns per warp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ CXX := amdclang++
 # Enable HIP. Use CXX=amdclang++ or CXX=hipcc 
 # Warning with hybrid OPENMP Compilations
 CXXFLAGS += -std=c++20 --offload-arch=native -mavx2 -faligned-new -DSSE_AVX2
-CXXFLAGS += -x hip -DHIP_KERNELS -D__HIP_PLATFORM_AMD__
+CXXFLAGS += -x hip -DHIP_KERNELS -D__HIP_PLATFORM_AMD__ -DHIP_ENABLE_WARP_SYNC_BUILTINS
 
 #
 # NVIDIA HPC SDK flags options

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -381,8 +381,7 @@ inline void EEU8_lazyF(const SSERegI vf0,
 // Helper for saturating subtraction (unsigned 8-bit)
 // No CDNA builtin.
 __device__ __forceinline__ uint8_t subs_u8(uint8_t a, uint8_t b) {
-    int res = (int)a - (int)b;
-    return (uint8_t)(res < 0 ? 0 : res);
+    return a-min(a,b);
 }
 
 
@@ -402,15 +401,17 @@ uint8_t EEU8_alignOne_HIP(
         const uint8_t rdgapo,
         const uint8_t rdgape)
 {
-    int lane_id = threadIdx.x;
+    int lane_id = threadIdx.x % 32;
     const int LANES = 32;
+    int lane_id_b = (threadIdx.x > 31) ? 1 : 0;
+    unsigned long long bitmask = (lane_id_b == 0) ? 0x0000000FFFFFFFFULL : 0xFFFFFFFF00000000ULL;
 
     uint8_t vf = 0;
 
     // load last H from previous column
     uint8_t vh = pvHLoad[(colstride - ROWSTRIDE) * LANES + lane_id];
 
-    vh = __shfl_up(vh, 1, LANES);
+    vh = __shfl_up_sync(bitmask, vh, 1, LANES);
 
     // in cpu the corresponding vh lane
     // is just orred with 0xff via vhilsw
@@ -484,10 +485,13 @@ void EEU8_lazyF_HIP(
         const uint8_t rdgapo)
 {
     const int WARP_SIZE = 32;
-    int lane_id = threadIdx.x;
-    assert(WARP_SIZE=32);
+    int lane_id = threadIdx.x % 32;
+    int lane_id_b = (threadIdx.x > 31) ? 1 : 0;
+    unsigned long long bitmask = (lane_id_b == 0) ? 0x0000000FFFFFFFFULL : 0xFFFFFFFF00000000ULL;
 
-    uint8_t vf = __shfl_up(vf0, 1, WARP_SIZE);
+    assert(WARP_SIZE==32);
+
+    uint8_t vf = __shfl_up_sync(bitmask, vf0, 1, WARP_SIZE);
     if(lane_id==0) vf = 0;
 
     pvScore += WARP_SIZE;
@@ -500,9 +504,9 @@ void EEU8_lazyF_HIP(
 
     vf = max(vtmp, vf);
 
-    bool anygt = vf > vtmp;
+    bool anygt = (vf > vtmp);
 
-    unsigned mask = __ballot(anygt);
+    unsigned long long mask = __ballot_sync(bitmask, anygt); // 32 predicate gets first lanes in thread
 
     uint8_t vh = pvHStore[lane_id];
     uint8_t ve = pvEStore[lane_id];
@@ -538,7 +542,7 @@ void EEU8_lazyF_HIP(
             pvHStore -= colstride*WARP_SIZE;
             pvEStore -= colstride*WARP_SIZE;
 
-            vf = __shfl_up(vf, 1, WARP_SIZE);
+            vf = __shfl_up_sync(bitmask, vf, 1, WARP_SIZE);
 	    if(lane_id==0)vf=0;
         }
 
@@ -550,9 +554,10 @@ void EEU8_lazyF_HIP(
 
         vf = max(vtmp, vf);
 
-        anygt = vf > vtmp;
+        anygt = (vf > vtmp);
 
-        mask = __ballot(anygt);
+        mask = __ballot_sync(bitmask, anygt);
+        //mask = __ballot(anygt);
 
         vh = pvHStore[lane_id];
         ve = pvEStore[lane_id];
@@ -582,11 +587,11 @@ void EEU8_alignNucleotides_HIP(
     )
 {
     // Each thread handles one lane, must be 32
-    int WARP_SIZE = blockDim.x;
+    int WARP_SIZE = 32;//blockDim.x;
     //if(WARP_SIZE!=32){fprintf(stderr, "Why is WARP_SIZE for EEU8_alignNucleotides_HIP not 32?\n");};
-    int lane_id = threadIdx.x % WARP_SIZE;
+    int lane_id = threadIdx.x % 32;
+    //int lane_id_g = (threadIdx.x>31) ? 1 : 0;
 
-    assert(WARP_SIZE==32);
 
     //Fills rdgapo values with readGapOpen
     uint8_t rfgapo = refGapOpen;

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -131,7 +131,8 @@ void EEU8_alignNucleotidesBatch_HIP(int npar, int nels,
 
     const int bx = blockIdx.x; // parallel task (1 per gpu block)
     const int elp_pp = (nels+ (npar-1))/npar; // round up
-    const int lane_id = threadIdx.x;// used for output and debugging in this wrapper function.
+    int lane_id_b = (threadIdx.x > 31) ? 1 : 0;
+    const int lane_id = threadIdx.x % 32;// used for output and debugging in this wrapper function.
 
 
     uint32_t nerrs_npar = 0;
@@ -139,14 +140,10 @@ void EEU8_alignNucleotidesBatch_HIP(int npar, int nels,
     // Equivalently the grid dimension
     //int curBatchSize = std::min(elp_pp,nels-bx*elp_pp);
 
-    int offset = bx*elp_pp;
-
-    if (offset >= nels) return; // should never run
-
-
+    if(threadIdx.x <= 31) return;
 
     const int iend = std::min((bx+1)*elp_pp,nels);
-    for (int i=bx*elp_pp; i<iend; i++) {
+    for (int i=bx*elp_pp+lane_id_b; i<iend; i+=2) {
 	    // leave each block to parallelize
 	    // where each block does 32 lanes.
 
@@ -168,8 +165,8 @@ void EEU8_alignNucleotidesBatch_HIP(int npar, int nels,
 
 	    // NOTE: Use globalIdx here too, otherwise every block in the batch 
 	    // writes to the same 'p'... not used yet
-	    SSERegI* mat             = mat_ + (bx * size_t(MAX_MAT_EL));
-	    DpBtCandidate* btncand   = btncand_ + (bx * size_t(MAX_RF_EL));
+	    SSERegI* mat             = mat_ + ((2*bx+lane_id_b) * size_t(MAX_MAT_EL));
+	    DpBtCandidate* btncand   = btncand_ + ((2*bx+lane_id_b) * size_t(MAX_RF_EL));
 
 
 	    // Updates btnfilled and lrmax
@@ -198,7 +195,10 @@ void EEU8_alignNucleotidesBatch_HIP(int npar, int nels,
     }
 
 
-    if(lane_id==0) nerrs[bx] = nerrs_npar;
+    // 
+    if (nerrs_npar > 0) {
+       atomicAdd(&nerrs[bx], nerrs_npar);
+    }
 }
 
 
@@ -220,10 +220,15 @@ int align_ee8_batchLaunch(const int npar, const int nels,
                 const int32_t ref_lrmax_[],
                 const int32_t ref_btnfilled_[]) {
 
-      uint32_t* nerrs = (uint32_t*)malloc(npar*sizeof(uint32_t));
+      uint32_t* nerrs
+#ifndef NO_CHECK_PRINT
+	 = (uint32_t*)calloc(npar, sizeof(uint32_t));
+#else
+	 = (uint32_t*)malloc(npar*sizeof(uint32_t)); // left here for compatibility, but values are probably bogus
+#endif
 
       // Handle all the proper indexing in this call.
-      EEU8_alignNucleotidesBatch_HIP<<<npar, 32>>>(npar, nels,
+      EEU8_alignNucleotidesBatch_HIP<<<npar, 64>>>(npar, nels,
 	    nrow_, iter_, colstride_, lastWordIdx_, minsc_, rfd_,
 	    profbuf_, rf_, gaps_,
 	    mat_, btncand_,
@@ -333,7 +338,7 @@ int load_and_align_ee8(const int npar, const int nels) {
    int32_t *ref_lrmax = new int32_t[nels];
    int32_t *ref_btnfilled = new int32_t[nels];
    SSERegI *profbuf = new SSERegI[size_t(nels)*MAX_PB_EL];
-   SSERegI *mat = new SSERegI[size_t(npar)*MAX_MAT_EL];
+   SSERegI *mat = new SSERegI[size_t(npar)*MAX_MAT_EL*2]; // *2 since we are using 32 threads independently in 64 threads
    char    *rf = new char[size_t(MAX_RF_EL)*nels];
    size_t  *nrow = new size_t[nels];
    size_t  *iter = new size_t[nels];
@@ -342,7 +347,7 @@ int load_and_align_ee8(const int npar, const int nels) {
    size_t  *minsc = new size_t[nels];
    size_t  *rfd = new size_t[nels];
    uint8_t *gaps = new uint8_t[4*nels];
-   DpBtCandidate    *btncand = new DpBtCandidate[size_t(MAX_RF_EL)*npar];
+   DpBtCandidate    *btncand = new DpBtCandidate[size_t(MAX_RF_EL)*npar*2]; // *2 for the same reason as before.
 
    auto t1 = std::chrono::high_resolution_clock::now();
    // test tool, don't worry about perfect cleanup


### PR DESCRIPTION
Add flag to enable warp sync builtin.
Changes functions to sync and masking, allocate 2x for block related variables,
  and some error checking.