### PR TITLE
Add EEU8_alignNucleotidesLRScalar, which only returns lrmax but at a reduced cost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ CXX := amdclang++
 # CXX := hipcc
 
 # CPU-only
-CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_FAST_SCALAR -DSSE_SCALAR
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_FAST_SCALAR -DSSE_SCALAR
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
+CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
 
 #
 # GPU-enabled

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_FAST_SCALAR -D
 #
 # GPU-enabled
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2 -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_FAST_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
 
 # Enable HIP. Use CXX=amdclang++ or CXX=hipcc 
 # Warning with hybrid OPENMP Compilations

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_FAST_SCALAR -D
 #
 # GPU-enabled
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2 -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_FAST_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_FAST_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
 
 # Enable HIP. Use CXX=amdclang++ or CXX=hipcc 
 # Warning with hybrid OPENMP Compilations

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,9 @@ CXX := amdclang++
 # CXX := hipcc
 
 # CPU-only
+CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_FAST_SCALAR -DSSE_SCALAR
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR
-CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
 
 #
 # GPU-enabled

--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,14 @@ CXX := amdclang++
 # CXX := hipcc
 
 # CPU-only
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_FAST_SCALAR -DSSE_SCALAR
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR
 CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
 
 #
 # GPU-enabled
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2 -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_FAST_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
 
 # Enable HIP. Use CXX=amdclang++ or CXX=hipcc 
 # Warning with hybrid OPENMP Compilations

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -574,8 +574,9 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  	uint8_t vs0 = profbuf[off+2*j];    // pvScore[2*j]
 		  	uint8_t vs1 = profbuf[off+2*j+1];
 
-		  	// Load cells from E, calculated previously
+		  	// Load cells from E and H, calculated previously
 			uint8_t ve = pvE[j];
+		  	uint8_t vh_next = pvH[j];
 
 			// Store cells in F, calculated previously
 			vf = subs_u8(vf, vs1); // veto some ref gap extensions
@@ -596,9 +597,6 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  	ve = subs_u8(ve, rdgape);
 		  	ve = std::max(ve, vh);
 
-		  	// Load the next h value
-			vh = pvH[j];
-		  	
 		  	// Save E and H values for next i round
 		  	pvE[j] = ve;
 		  	pvH[j] = vtmp;
@@ -607,6 +605,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  	vtmp = subs_u8(vtmp, rfgapo);
 		  	vf = subs_u8(vf, rfgape);
 		  	vf = std::max(vf, vtmp);
+			vh = vh_next;
 		  }
 		}
 

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -504,18 +504,12 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
  *   rf      - reference sequence
  *
  */
-template<typename TIdxSize>
-inline EEU8_TCScore EEU8_alignNucleotidesScalar(const SSERegI profbuf[],
+template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151>
+inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 					const char   rf[], const TIdxSize rfd,
 					const TIdxSize iter, const size_t colstride, const size_t lastWordIdx,
 					const size_t nrow,
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
-	// Set all elts to reference gap open penalty
-	uint8_t pvE[MAX_QUERY_SIZE*2];
-	uint8_t pvH[MAX_QUERY_SIZE*2];
-	// equivalently the max query size is the size of the column in scalar mode
-	// so variable 'iter' can be used
-	uint32_t pvOffset = MAX_QUERY_SIZE;
 
 	assert_gt(refGapOpen, 0);
 	uint8_t rfgapo = uint8_t(refGapOpen);
@@ -539,11 +533,10 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const SSERegI profbuf[],
 	// Maximum score in final row
 	EEU8_TCScore lrmax = MIN_U8;
 
+	// Set all elts to reference gap open penalty
 	// Initialize the H and E vectors in the first matrix column
-	for(size_t i = 0; i < iter; i++) {
-	      pvE[i] = 0;
-	      pvH[i] = 0;
-	}
+	uint8_t pvE[MAX_ITER] = {0};
+	uint8_t pvH[MAX_ITER] = {0};
 
 	// Fill in the table as usual but instead of using the same gap-penalty
 	// vector for each iteration of the inner loop, load words out of a
@@ -582,8 +575,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const SSERegI profbuf[],
 		  	uint8_t vs1 = profbuf[off+2*j+1];
 
 		  	// Load cells from E, calculated previously
-			uint8_t ve;
-			ve =  pvE[(i%2)*pvOffset+j];
+			uint8_t ve = pvE[j];
 
 			// Store cells in F, calculated previously
 			vf = subs_u8(vf, vs1); // veto some ref gap extensions
@@ -596,22 +588,22 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const SSERegI profbuf[],
 		  	vh = std::max(vh, vf);
 		  	
 		  	// Save the new vH values
-			pvH[((i+1)%2)*pvOffset+j] = vh;
+		  	uint8_t vtmp = vh;
 		  	
 		  	// Update vE value
-		  	uint8_t vtmp = vh;
 		  	vh = subs_u8(vh, rdgapo);
 		  	vh = subs_u8(vh, vs1); // veto some read gap opens
 		  	ve = subs_u8(ve, rdgape);
 		  	ve = std::max(ve, vh);
 
 		  	// Load the next h value
-			vh = pvH[(i%2)*pvOffset + j];
+			vh = pvH[j];
 		  	
-		  	// Save E values
-		  	pvE[((i+1)%2)*pvOffset + j] = ve;
+		  	// Save E and H values for next i round
+		  	pvE[j] = ve;
+		  	pvH[j] = vtmp;
 		  	
-		  	// Update vf value
+		  	// Update vf value for next round
 		  	vtmp = subs_u8(vtmp, rfgapo);
 		  	vf = subs_u8(vf, rfgape);
 		  	vf = std::max(vf, vtmp);
@@ -620,7 +612,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const SSERegI profbuf[],
 
 		// Note: we may not want to extract from the final row
 		//       EEU8_TCScore == uint8_t == uint8_t
-		EEU8_TCScore lr = pvH[((i+1)%2)*pvOffset+ iter - 1];
+		EEU8_TCScore lr = pvH[iter - 1];
 		if(lr > lrmax) {
 			lrmax = lr;
 		}

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -497,7 +497,9 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
 /**
  * Like the previous alignNucleotides, but the Scalar version allows to forfeit some extra strutures.
  * Note that this version does not return the E, F, H vectors.
- * If those are needed, e.g. when (lrmax - 0xff)>=minsc, i.e. btnfilled>0, use the regular, full version.
+ * Only lrmax is computed and returned.
+ *
+ * If the vectors are needed, e.g. when (lrmax - 0xff)>=minsc, i.e. btnfilled>0, use the regular, full version.
  *
  * Select intput parameters:
  *   profbuf - buffer for query profile & temp vecs
@@ -505,7 +507,7 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
  *
  */
 template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151>
-inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
+inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 					const char   rf[], const TIdxSize rfd,
 					const size_t nrow,
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
@@ -829,13 +831,24 @@ bool SwAligner::alignEnd2EndSseU8(
 	uint16_t btnfilled = 0;
 	btncand_.resizeNoCopy(rflen_); // cannot be bigger that this
 
-#ifdef SSE_FAST_SCALAR
-	const EEU8_TCScore lrmax = EEU8_alignNucleotidesScalar<uint16_t>(d.profbuf_.ptr(), rf_, rflen_,
+#if 0
+	// When SSE_FAST_SCALAR
+	// TODO: Consider the use of EEU8_alignNucleotidesLRScalar
+	EEU8_TCScore lrmax = 255;
+	if ((iter!=151) {
+	        lrmax= EEU8_alignNucleotidesLRScalar<uint16_t,151>(d.profbuf_.ptr(), rf_, rflen_,
+					dpRows(),
+					sc_->refGapOpen(), sc_->refGapExtend(), sc_->readGapOpen(), sc_->readGapExtend());
+	}
+	TAlScore sc = (TAlScore)(lrmax - 0xff);
+        if (sc>=minsc_)) {
+		lrmax = EEU8_alignNucleotides<uint16_t>(d.profbuf_.ptr(), rf_, rflen_,
 					d.mat_.ptr(),
                                         iter, d.mat_.colstride(), lastWordIdx,
 					minsc_, dpRows(),
 					btncand_.ptr(), btnfilled,
 					sc_->refGapOpen(), sc_->refGapExtend(), sc_->readGapOpen(), sc_->readGapExtend());
+	}
 #else
 	const EEU8_TCScore lrmax = EEU8_alignNucleotides<uint16_t>(d.profbuf_.ptr(), rf_, rflen_,
 					d.mat_.ptr(),

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -77,6 +77,13 @@
 
 typedef uint8_t EEU8_TCScore;
 
+
+// Helper for saturating subtraction (unsigned 8-bit)
+// since there is no such thing in standard C++.
+constexpr uint8_t subs_u8(uint8_t a, uint8_t b) {
+    return a-std::min(a,b);
+}
+
 /**
  * Build query profile look up tables for the read.  The query profile look
  * up table is organized as a 1D array indexed by [i][j] where i is the
@@ -486,6 +493,156 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
 	return lrmax;
 }
 
+
+/**
+ * Like the previous alignNucleotides, but the Scalar version allows to forfeit some extra strutures
+ *
+ * Select intput parameters:
+ *   profbuf - buffer for query profile & temp vecs
+ *   rf      - reference sequence
+ *
+ * Select output parameters:
+ *   pmat    - SSE matrix for holding all E, F, H vectors
+ *   btncand - cells we might backtrace from
+ */
+template<typename TIdxSize>
+inline EEU8_TCScore EEU8_alignNucleotidesScalar(const SSERegI profbuf[],
+					const char   rf[], const TIdxSize rfd,
+					const TIdxSize iter, const size_t colstride, const size_t lastWordIdx,
+					const TAlScore minsc, const size_t nrow,
+					DpBtCandidate btncand[], TIdxSize& btnfilled_,
+					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
+	// Set all elts to reference gap open penalty
+	uint8_t pvE[MAX_QUERY_SIZE*2];
+	uint8_t pvH[MAX_QUERY_SIZE*2];
+	// equivalently the max query size is the size of the column in scalar mode
+	// so variable 'iter' can be used
+	uint32_t pvOffset = MAX_QUERY_SIZE;
+
+	assert_gt(refGapOpen, 0);
+	uint8_t rfgapo = uint8_t(refGapOpen);
+	
+	// Set all elts to reference gap extension penalty
+	assert_gt(refGapExtend, 0);
+	assert_leq(refGapExtend, refGapOpen);
+	uint8_t rfgape = uint8_t(refGapExtend);
+
+	// Set all elts to read gap open penalty
+	assert_gt(readGapOpen, 0);
+	uint8_t rdgapo = uint8_t(readGapOpen);
+	
+	// Set all elts to read gap extension penalty
+	assert_gt(readGapExtend, 0);
+	assert_leq(readGapExtend, readGapOpen);
+	uint8_t rdgape = uint8_t(readGapExtend);
+
+	assert_eq(ROWSTRIDE, colstride / iter);
+
+	// Maximum score in final row
+	EEU8_TCScore lrmax = MIN_U8;
+
+	// keep a local copy
+	TIdxSize btnfilled = 0;
+
+	// Initialize the H and E vectors in the first matrix column
+	for(size_t i = 0; i < iter; i++) {
+	      pvE[i] = 0;
+	      pvH[i] = 0;
+	}
+
+	// Fill in the table as usual but instead of using the same gap-penalty
+	// vector for each iteration of the inner loop, load words out of a
+	// pre-calculated gap vector parallel to the query profile.  The pre-
+	// calculated gap vectors enforce the gap barrier constraint by making it
+	// infinitely costly to introduce a gap in barrier rows.
+	//
+	// AND use a separate loop to fill in the first row of the table, enforcing
+	// the st_ constraints in the process.  This is awkward because it
+	// separates the processing of the first row from the others and might make
+	// it difficult to use the first-row results in the next row, but it might
+	// be the simplest and least disruptive way to deal with the st_ constraint.
+
+	for(TIdxSize i = 0; i < rfd; i++) {
+		
+		// Fetch the appropriate query profile.  Note that elements of rf must
+		// be numbers, not masks.
+		size_t off = (size_t)std::countr_zero( uint8_t(rf[i]) ) * iter * 2;
+		// points into the query profile
+		//const uint8_t *pvScore = profbuf + off; // even elts = query profile, odd = gap barrier
+	
+		// scalar version of EEU8_alignOne()
+		{
+		  // vhilsw: topmost (least sig) word set to 0xff, all other words=0
+		  uint8_t vhilsw   = 0xff;
+	
+		  // Set all cells to low value
+		  uint8_t vf       = 0;
+
+		  // in scalar mode, we always start high
+		  uint8_t vh = vhilsw; //0xff
+
+		  // For each character in the reference text:
+		  for(TIdxSize j = 0; j < iter; j++) {
+		  	uint8_t vs0 = profbuf[off+2*j];    // pvScore[2*j]
+		  	uint8_t vs1 = profbuf[off+2*j+1];
+
+		  	// Load cells from E, calculated previously
+			uint8_t ve;
+			ve =  pvE[(i%2)*pvOffset+j];
+
+			// Store cells in F, calculated previously
+			vf = subs_u8(vf, vs1); // veto some ref gap extensions
+		  	
+		  	// Factor in query profile (matches and mismatches)
+		  	vh = subs_u8(vh, vs0);
+		  	
+		  	// Update H, factoring in E and F
+		  	vh = std::max(vh, ve);
+		  	vh = std::max(vh, vf);
+		  	
+		  	// Save the new vH values
+			pvH[((i+1)%2)*pvOffset+j] = vh;
+		  	
+		  	// Update vE value
+		  	uint8_t vtmp = vh;
+		  	vh = subs_u8(vh, rdgapo);
+		  	vh = subs_u8(vh, vs1); // veto some read gap opens
+		  	ve = subs_u8(ve, rdgape);
+		  	ve = std::max(ve, vh);
+
+		  	// Load the next h value
+			vh = pvH[(i%2)*pvOffset + j];
+		  	
+		  	// Save E values
+		  	pvE[((i+1)%2)*pvOffset + j] = ve;
+		  	
+		  	// Update vf value
+		  	vtmp = subs_u8(vtmp, rfgapo);
+		  	vf = subs_u8(vf, rfgape);
+		  	vf = std::max(vf, vtmp);
+		  }
+		}
+
+		// Note: we may not want to extract from the final row
+		//       EEU8_TCScore == uint8_t == uint8_t
+		EEU8_TCScore lr = pvH[((i+1)%2)*pvOffset+ iter - 1];
+		TAlScore sc = (TAlScore)(lr - 0xff);
+		if(lr > lrmax) {
+			lrmax = lr;
+		}
+		if(sc >= minsc) {
+			// Yes, this is legit
+			btncand[btnfilled].init(nrow-1, i, lr);
+			btnfilled++;
+		}
+
+	}
+
+
+	btnfilled_ = btnfilled;  // pass it out
+	return lrmax;
+}
+
 #ifndef SWSSE_INLINE_ONLY
 /**
  * Align read 'rd' to reference using read & reference information given
@@ -565,12 +722,21 @@ bool SwAligner::alignEnd2EndSseU8(
 	uint16_t btnfilled = 0;
 	btncand_.resizeNoCopy(rflen_); // cannot be bigger that this
 
+#ifdef SSE_FAST_SCALAR
+	const EEU8_TCScore lrmax = EEU8_alignNucleotidesScalar<uint16_t>(d.profbuf_.ptr(), rf_, rflen_,
+					d.mat_.ptr(),
+                                        iter, d.mat_.colstride(), lastWordIdx,
+					minsc_, dpRows(),
+					btncand_.ptr(), btnfilled,
+					sc_->refGapOpen(), sc_->refGapExtend(), sc_->readGapOpen(), sc_->readGapExtend());
+#else
 	const EEU8_TCScore lrmax = EEU8_alignNucleotides<uint16_t>(d.profbuf_.ptr(), rf_, rflen_,
 					d.mat_.ptr(),
                                         iter, d.mat_.colstride(), lastWordIdx,
 					minsc_, dpRows(),
 					btncand_.ptr(), btnfilled,
 					sc_->refGapOpen(), sc_->refGapExtend(), sc_->readGapOpen(), sc_->readGapExtend());
+#endif
 	btncand_.trim(btnfilled);
 	state_ = STATE_ALIGNED;
 	cural_ = 0;

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -495,22 +495,20 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
 
 
 /**
- * Like the previous alignNucleotides, but the Scalar version allows to forfeit some extra strutures
+ * Like the previous alignNucleotides, but the Scalar version allows to forfeit some extra strutures.
+ * Note that this version does not return the E, F, H vectors.
+ * If those are needed, e.g. when (lrmax - 0xff)>=minsc, i.e. btnfilled>0, use the regular, full version.
  *
  * Select intput parameters:
  *   profbuf - buffer for query profile & temp vecs
  *   rf      - reference sequence
  *
- * Select output parameters:
- *   pmat    - SSE matrix for holding all E, F, H vectors
- *   btncand - cells we might backtrace from
  */
 template<typename TIdxSize>
 inline EEU8_TCScore EEU8_alignNucleotidesScalar(const SSERegI profbuf[],
 					const char   rf[], const TIdxSize rfd,
 					const TIdxSize iter, const size_t colstride, const size_t lastWordIdx,
-					const TAlScore minsc, const size_t nrow,
-					DpBtCandidate btncand[], TIdxSize& btnfilled_,
+					const size_t nrow,
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
 	// Set all elts to reference gap open penalty
 	uint8_t pvE[MAX_QUERY_SIZE*2];
@@ -540,9 +538,6 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const SSERegI profbuf[],
 
 	// Maximum score in final row
 	EEU8_TCScore lrmax = MIN_U8;
-
-	// keep a local copy
-	TIdxSize btnfilled = 0;
 
 	// Initialize the H and E vectors in the first matrix column
 	for(size_t i = 0; i < iter; i++) {
@@ -626,20 +621,11 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const SSERegI profbuf[],
 		// Note: we may not want to extract from the final row
 		//       EEU8_TCScore == uint8_t == uint8_t
 		EEU8_TCScore lr = pvH[((i+1)%2)*pvOffset+ iter - 1];
-		TAlScore sc = (TAlScore)(lr - 0xff);
 		if(lr > lrmax) {
 			lrmax = lr;
 		}
-		if(sc >= minsc) {
-			// Yes, this is legit
-			btncand[btnfilled].init(nrow-1, i, lr);
-			btnfilled++;
-		}
-
 	}
 
-
-	btnfilled_ = btnfilled;  // pass it out
 	return lrmax;
 }
 

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -511,15 +511,24 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
         class TPackedEH {
 	private:
-		uint16_t val;
+		uint32_t val;
 	public:
 		constexpr TPackedEH() : val(0) {};
 		constexpr TPackedEH(const TPackedEH& other) : val(other.val) {}
+		constexpr TPackedEH& operator=(const TPackedEH& other) { val = other.val; return *this;}
 
-		constexpr void set(uint8_t E, uint8_t H) { val = (uint16_t(H)<<8) + uint16_t(E);}
+		constexpr void set(uint8_t E_even, uint8_t H_even, uint8_t E_odd, uint8_t H_odd) { val =(uint32_t(H_odd)<<24) | (uint32_t(E_odd)<<16) |  (uint32_t(H_even)<<8) | uint32_t(E_even);}
+		constexpr void set(uint8_t E_even, uint8_t H_even) { val = (uint32_t(H_even)<<8) | uint32_t(E_even);}
 
-		constexpr uint8_t get_E() const {return uint8_t(val); }
-		constexpr uint8_t get_H() const {return uint8_t(val>>8); }
+		// preserve odd, update even (low 16 bits)
+		constexpr void set_even(uint8_t E, uint8_t H) { val = (val & uint32_t(0xffff0000U)) | ((uint32_t(H)<<8) | uint32_t(E));}
+		// preserve even, update odd (high 16 bits)
+		constexpr void set_odd(uint8_t E, uint8_t H) { val = (val & uint32_t(0xffffU)) | ((uint32_t(H)<<24) | (uint32_t(E)<<16));}
+
+		constexpr uint8_t get_E_even() const {return uint8_t(val); }
+		constexpr uint8_t get_H_even() const {return uint8_t(val>>8); }
+		constexpr uint8_t get_E_odd() const {return uint8_t(val>>16); }
+		constexpr uint8_t get_H_odd() const {return uint8_t(val>>24); }
 	};
 
         constexpr uint16_t iter = MAX_ITER;
@@ -546,7 +555,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 
 	// Set all elts to reference gap open penalty
 	// iAutomatic initialize the H and E vectors in the first matrix column
-	TPackedEH bufEH[MAX_ITER];
+	TPackedEH bufEH[(iter+1)/2];
 
 	// Fill in the table as usual but instead of using the same gap-penalty
 	// vector for each iteration of the inner loop, load words out of a
@@ -585,14 +594,18 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  // Only downsides for the CPUs, that have fewer registers
 #pragma omp unroll full
 #endif
-		  for(TIdxSize j = 0; j < iter; j++) {
+		  for(TIdxSize j2 = 0; j2 < (iter-1); j2+=2) {
+		    // Load cells from E and H, calculated previously
+		    TPackedEH full_eh(bufEH[j2/2]);
+		    // Even step
+		    {
+			const uint16_t j = j2;
 		  	uint8_t vs0 = profbuf[off+2*j];    // pvScore[2*j]
 		  	uint8_t vs1 = profbuf[off+2*j+1];
 
 		  	// Load cells from E and H, calculated previously
-			TPackedEH old_eh(bufEH[j]);
-			uint8_t ve = old_eh.get_E();
-		  	uint8_t vh_next = old_eh.get_H();
+			uint8_t ve = full_eh.get_E_even();
+		  	uint8_t vh_next = full_eh.get_H_even();
 
 			// Store cells in F, calculated previously
 			vf = subs_u8(vf, vs1); // veto some ref gap extensions
@@ -614,19 +627,96 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  	ve = std::max(ve, vh);
 
 		  	// Save E and H values for next i round
-		  	bufEH[j].set(ve,vtmp);
+		  	full_eh.set_even(ve,vtmp);
 		  	
 		  	// Update vf value for next round
 		  	vtmp = subs_u8(vtmp, rfgapo);
 		  	vf = subs_u8(vf, rfgape);
 		  	vf = std::max(vf, vtmp);
 			vh = vh_next;
+		    }
+		    // Odd step
+		    {
+			const uint16_t j = j2+1;
+		  	uint8_t vs0 = profbuf[off+2*j];    // pvScore[2*j]
+		  	uint8_t vs1 = profbuf[off+2*j+1];
+
+		  	// Load cells from E and H, calculated previously
+			uint8_t ve = full_eh.get_E_odd();
+		  	uint8_t vh_next = full_eh.get_H_odd();
+
+			// Store cells in F, calculated previously
+			vf = subs_u8(vf, vs1); // veto some ref gap extensions
+		  	
+		  	// Factor in query profile (matches and mismatches)
+		  	vh = subs_u8(vh, vs0);
+		  	
+		  	// Update H, factoring in E and F
+		  	vh = std::max(vh, ve);
+		  	vh = std::max(vh, vf);
+		  	
+		  	// Save the new vH values
+		  	uint8_t vtmp = vh;
+		  	
+		  	// Update vE value
+		  	vh = subs_u8(vh, rdgapo);
+		  	vh = subs_u8(vh, vs1); // veto some read gap opens
+		  	ve = subs_u8(ve, rdgape);
+		  	ve = std::max(ve, vh);
+
+		  	// Save E and H values for next i round
+		  	full_eh.set_odd(ve,vtmp);
+		  	
+		  	// Update vf value for next round
+		  	vtmp = subs_u8(vtmp, rfgapo);
+		  	vf = subs_u8(vf, rfgape);
+		  	vf = std::max(vf, vtmp);
+			vh = vh_next;
+		    }
+		    // save the packed result back for the next i loop
+		    bufEH[j2/2] = full_eh;
+		  }
+		  if constexpr((iter%2)!=0) {
+			// Last Even step
+			const uint16_t j = iter-1;
+		  	uint8_t vs0 = profbuf[off+2*j];    // pvScore[2*j]
+		  	uint8_t vs1 = profbuf[off+2*j+1];
+
+		  	// Load cells from E and H, calculated previously
+			TPackedEH full_eh(bufEH[iter/2]);
+			uint8_t ve = full_eh.get_E_even();
+			// no next round, do not need vh_next
+
+			// Store cells in F, calculated previously
+			vf = subs_u8(vf, vs1); // veto some ref gap extensions
+		  	
+		  	// Factor in query profile (matches and mismatches)
+		  	vh = subs_u8(vh, vs0);
+		  	
+		  	// Update H, factoring in E and F
+		  	vh = std::max(vh, ve);
+		  	vh = std::max(vh, vf);
+		  	
+		  	// Save the new vH values
+		  	uint8_t vtmp = vh;
+		  	
+		  	// Update vE value
+		  	vh = subs_u8(vh, rdgapo);
+		  	vh = subs_u8(vh, vs1); // veto some read gap opens
+		  	ve = subs_u8(ve, rdgape);
+		  	ve = std::max(ve, vh);
+
+		  	// Save E and H values for next i round
+		  	bufEH[iter/2].set(ve,vtmp);
+		  	
+		  	// no next round
 		  }
 		}
 
 		// Note: we may not want to extract from the final row
 		//       EEU8_TCScore == uint8_t == uint8_t
-		EEU8_TCScore lr = bufEH[iter - 1].get_H();
+		// Was: EEU8_TCScore lr = bufEH2[iter - 1].get_H();
+		EEU8_TCScore lr = ((iter%2)!=0) ? bufEH[iter/2].get_H_even() : bufEH[(iter-1)/2].get_H_odd();
 		if(lr > lrmax) {
 			lrmax = lr;
 		}

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -507,7 +507,7 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
 template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151>
 inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 					const char   rf[], const TIdxSize rfd,
-					const TIdxSize iter, const size_t colstride, const size_t lastWordIdx,
+					const TIdxSize iter_, const size_t colstride, const size_t lastWordIdx,
 					const size_t nrow,
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
         class TPackedEH {
@@ -522,6 +522,8 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		constexpr uint8_t get_E() const {return uint8_t(val); }
 		constexpr uint8_t get_H() const {return uint8_t(val>>8); }
 	};
+
+        constexpr uint16_t iter = MAX_ITER;
 
 	assert_gt(refGapOpen, 0);
 	uint8_t rfgapo = uint8_t(refGapOpen);
@@ -580,7 +582,12 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  // in scalar mode, we always start high
 		  uint8_t vh = vhilsw; //0xff
 
-		  // For each character in the reference text:
+		  // For each character in the reference text
+#ifdef OMPGPU
+		  // Full unrolling allows bufEH to be mapped to the GPU register file
+		  // Only downsides for the CPUs, that have fewer registers
+#pragma omp unroll full
+#endif
 		  for(TIdxSize j = 0; j < iter; j++) {
 		  	uint8_t vs0 = profbuf[off+2*j];    // pvScore[2*j]
 		  	uint8_t vs1 = profbuf[off+2*j+1];

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -531,6 +531,38 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		constexpr uint8_t get_H_odd() const {return uint8_t(val>>24); }
 	};
 
+        class TPackedScore {
+	private:
+		uint32_t val;
+	public:
+		constexpr TPackedScore() : val(0) {};
+		// Note: j must be even
+		constexpr TPackedScore(const uint8_t *pvScore, const uint16_t j) { val = ((uint32_t *)(pvScore+(2*j)))[0]; }
+
+		constexpr TPackedScore(const TPackedScore& other) : val(other.val) {}
+		constexpr TPackedScore& operator=(const TPackedScore& other) { val = other.val; return *this;}
+
+		constexpr uint8_t get_vs0_even() const {return uint8_t(val); }
+		constexpr uint8_t get_vs1_even() const {return uint8_t(val>>8); }
+		constexpr uint8_t get_vs0_odd() const {return uint8_t(val>>16); }
+		constexpr uint8_t get_vs1_odd() const {return uint8_t(val>>24); }
+	};
+
+        class TPackedScoreHalf {
+	private:
+		uint16_t val;
+	public:
+		constexpr TPackedScoreHalf() : val(0) {};
+		// Note: j must be even
+		constexpr TPackedScoreHalf(const uint8_t *pvScore, const uint16_t j) { val = ((uint16_t *)(pvScore+(2*j)))[0]; }
+
+		constexpr TPackedScoreHalf(const TPackedScoreHalf& other) : val(other.val) {}
+		constexpr TPackedScoreHalf& operator=(const TPackedScoreHalf& other) { val = other.val; return *this;}
+
+		constexpr uint8_t get_vs0_even() const {return uint8_t(val); }
+		constexpr uint8_t get_vs1_even() const {return uint8_t(val>>8); }
+	};
+
         constexpr uint16_t iter = MAX_ITER;
 
 	assert_gt(refGapOpen, 0);
@@ -575,7 +607,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		// be numbers, not masks.
 		size_t off = (size_t)std::countr_zero( uint8_t(rf[i]) ) * iter * 2;
 		// points into the query profile
-		//const uint8_t *pvScore = profbuf + off; // even elts = query profile, odd = gap barrier
+		const uint8_t *pvScore = profbuf + off; // even elts = query profile, odd = gap barrier
 	
 		// scalar version of EEU8_alignOne()
 		{
@@ -597,21 +629,19 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  for(TIdxSize j2 = 0; j2 < (iter-1); j2+=2) {
 		    // Load cells from E and H, calculated previously
 		    TPackedEH full_eh(bufEH[j2/2]);
+		    // Load the scores
+		    const TPackedScore full_score(pvScore,j2);
 		    // Even step
 		    {
-			const uint16_t j = j2;
-		  	uint8_t vs0 = profbuf[off+2*j];    // pvScore[2*j]
-		  	uint8_t vs1 = profbuf[off+2*j+1];
-
 		  	// Load cells from E and H, calculated previously
 			uint8_t ve = full_eh.get_E_even();
 		  	uint8_t vh_next = full_eh.get_H_even();
 
 			// Store cells in F, calculated previously
-			vf = subs_u8(vf, vs1); // veto some ref gap extensions
+			vf = subs_u8(vf, full_score.get_vs1_even()); // veto some ref gap extensions
 		  	
 		  	// Factor in query profile (matches and mismatches)
-		  	vh = subs_u8(vh, vs0);
+		  	vh = subs_u8(vh, full_score.get_vs0_even());
 		  	
 		  	// Update H, factoring in E and F
 		  	vh = std::max(vh, ve);
@@ -622,7 +652,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  	
 		  	// Update vE value
 		  	vh = subs_u8(vh, rdgapo);
-		  	vh = subs_u8(vh, vs1); // veto some read gap opens
+		  	vh = subs_u8(vh, full_score.get_vs1_even()); // veto some read gap opens
 		  	ve = subs_u8(ve, rdgape);
 		  	ve = std::max(ve, vh);
 
@@ -637,19 +667,15 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		    }
 		    // Odd step
 		    {
-			const uint16_t j = j2+1;
-		  	uint8_t vs0 = profbuf[off+2*j];    // pvScore[2*j]
-		  	uint8_t vs1 = profbuf[off+2*j+1];
-
 		  	// Load cells from E and H, calculated previously
 			uint8_t ve = full_eh.get_E_odd();
 		  	uint8_t vh_next = full_eh.get_H_odd();
 
 			// Store cells in F, calculated previously
-			vf = subs_u8(vf, vs1); // veto some ref gap extensions
+			vf = subs_u8(vf, full_score.get_vs1_odd()); // veto some ref gap extensions
 		  	
 		  	// Factor in query profile (matches and mismatches)
-		  	vh = subs_u8(vh, vs0);
+		  	vh = subs_u8(vh, full_score.get_vs0_odd());
 		  	
 		  	// Update H, factoring in E and F
 		  	vh = std::max(vh, ve);
@@ -660,7 +686,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  	
 		  	// Update vE value
 		  	vh = subs_u8(vh, rdgapo);
-		  	vh = subs_u8(vh, vs1); // veto some read gap opens
+		  	vh = subs_u8(vh, full_score.get_vs1_odd()); // veto some read gap opens
 		  	ve = subs_u8(ve, rdgape);
 		  	ve = std::max(ve, vh);
 
@@ -678,20 +704,19 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  }
 		  if constexpr((iter%2)!=0) {
 			// Last Even step
-			const uint16_t j = iter-1;
-		  	uint8_t vs0 = profbuf[off+2*j];    // pvScore[2*j]
-		  	uint8_t vs1 = profbuf[off+2*j+1];
-
 		  	// Load cells from E and H, calculated previously
-			TPackedEH full_eh(bufEH[iter/2]);
+			const TPackedEH full_eh(bufEH[iter/2]);
+		        // Load the scores
+		        const TPackedScoreHalf full_score(pvScore, iter-1);
+
 			uint8_t ve = full_eh.get_E_even();
 			// no next round, do not need vh_next
 
 			// Store cells in F, calculated previously
-			vf = subs_u8(vf, vs1); // veto some ref gap extensions
+			vf = subs_u8(vf, full_score.get_vs1_even()); // veto some ref gap extensions
 		  	
 		  	// Factor in query profile (matches and mismatches)
-		  	vh = subs_u8(vh, vs0);
+		  	vh = subs_u8(vh, full_score.get_vs0_even());
 		  	
 		  	// Update H, factoring in E and F
 		  	vh = std::max(vh, ve);
@@ -702,7 +727,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  	
 		  	// Update vE value
 		  	vh = subs_u8(vh, rdgapo);
-		  	vh = subs_u8(vh, vs1); // veto some read gap opens
+		  	vh = subs_u8(vh, full_score.get_vs1_even()); // veto some read gap opens
 		  	ve = subs_u8(ve, rdgape);
 		  	ve = std::max(ve, vh);
 

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -510,6 +510,18 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 					const TIdxSize iter, const size_t colstride, const size_t lastWordIdx,
 					const size_t nrow,
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
+        class TPackedEH {
+	private:
+		uint16_t val;
+	public:
+		constexpr TPackedEH() : val(0) {};
+		constexpr TPackedEH(const TPackedEH& other) : val(other.val) {}
+
+		constexpr void set(uint8_t E, uint8_t H) { val = (uint16_t(H)<<8) + uint16_t(E);}
+
+		constexpr uint8_t get_E() const {return uint8_t(val); }
+		constexpr uint8_t get_H() const {return uint8_t(val>>8); }
+	};
 
 	assert_gt(refGapOpen, 0);
 	uint8_t rfgapo = uint8_t(refGapOpen);
@@ -534,9 +546,8 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 	EEU8_TCScore lrmax = MIN_U8;
 
 	// Set all elts to reference gap open penalty
-	// Initialize the H and E vectors in the first matrix column
-	uint8_t pvE[MAX_ITER] = {0};
-	uint8_t pvH[MAX_ITER] = {0};
+	// iAutomatic initialize the H and E vectors in the first matrix column
+	TPackedEH bufEH[MAX_ITER];
 
 	// Fill in the table as usual but instead of using the same gap-penalty
 	// vector for each iteration of the inner loop, load words out of a
@@ -575,8 +586,9 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  	uint8_t vs1 = profbuf[off+2*j+1];
 
 		  	// Load cells from E and H, calculated previously
-			uint8_t ve = pvE[j];
-		  	uint8_t vh_next = pvH[j];
+			TPackedEH old_eh(bufEH[j]);
+			uint8_t ve = old_eh.get_E();
+		  	uint8_t vh_next = old_eh.get_H();
 
 			// Store cells in F, calculated previously
 			vf = subs_u8(vf, vs1); // veto some ref gap extensions
@@ -598,8 +610,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 		  	ve = std::max(ve, vh);
 
 		  	// Save E and H values for next i round
-		  	pvE[j] = ve;
-		  	pvH[j] = vtmp;
+		  	bufEH[j].set(ve,vtmp);
 		  	
 		  	// Update vf value for next round
 		  	vtmp = subs_u8(vtmp, rfgapo);
@@ -611,7 +622,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 
 		// Note: we may not want to extract from the final row
 		//       EEU8_TCScore == uint8_t == uint8_t
-		EEU8_TCScore lr = pvH[iter - 1];
+		EEU8_TCScore lr = bufEH[iter - 1].get_H();
 		if(lr > lrmax) {
 			lrmax = lr;
 		}

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -507,7 +507,6 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
 template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151>
 inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 					const char   rf[], const TIdxSize rfd,
-					const TIdxSize iter_, const size_t colstride, const size_t lastWordIdx,
 					const size_t nrow,
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
         class TPackedEH {
@@ -541,8 +540,6 @@ inline EEU8_TCScore EEU8_alignNucleotidesScalar(const uint8_t profbuf[],
 	assert_gt(readGapExtend, 0);
 	assert_leq(readGapExtend, readGapOpen);
 	uint8_t rdgape = uint8_t(readGapExtend);
-
-	assert_eq(ROWSTRIDE, colstride / iter);
 
 	// Maximum score in final row
 	EEU8_TCScore lrmax = MIN_U8;

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -832,7 +832,7 @@ bool SwAligner::alignEnd2EndSseU8(
 	btncand_.resizeNoCopy(rflen_); // cannot be bigger that this
 
 #if 0
-	// When SSE_FAST_SCALAR
+	// When PRE_LR_SCALAR
 	// TODO: Consider the use of EEU8_alignNucleotidesLRScalar
 	EEU8_TCScore lrmax = 255;
 	if ((iter!=151) {

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -2,24 +2,6 @@
  * Simple exerciser of aligner_swsse_ee_u8.cpp
  */
 
-// assumed CDNA where warp size is 64. 32 on Nvidia and RDNA
-#ifndef WARP_SIZE
-#define WARP_SIZE 64
-#endif
-
-#ifndef SSE_FAST_SCALAR
- #ifndef E_PER_WARP
-  #define E_PER_WARP 2
- #endif
- #ifndef LANE_SIZE
-  #define LANE_SIZE 32 // number of lanes used in this
- #endif
-#else // enabled SSE_FAST_SCALAR
- #define E_PER_WARP 1
- #define LANE_SIZE 1
- #define MAX_QUERY_SIZE 604 // empirical value at the moment
-#endif // SSE_FAST_SCALAR
-
 #define SWSSE_INLINE_ONLY
 
 #include "../aligner_swsse_ee_u8.cpp"

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -111,7 +111,7 @@ int align_ee8_one(const int el, // for debuggging purpose
 #else
 	// Note: The vast majority of reads have iter==151
 	if (iter!=151) return 0;  // TODO: We may properly use the right template function, or call slow align directly
-	const EEU8_TCScore lrmax = EEU8_alignNucleotidesScalar<uint16_t,151>(profbuf, rf, rfd,
+	const EEU8_TCScore lrmax = EEU8_alignNucleotidesLRScalar<uint16_t,151>(profbuf, rf, rfd,
 					nrow,
 					gaps[0],gaps[1],gaps[2],gaps[3]);
 #endif

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -101,6 +101,7 @@ int align_ee8_one(const int el, // for debuggging purpose
                 const int32_t ref_lrmax,
                 const int32_t ref_btnfilled) {
 #ifndef SSE_FAST_SCALAR
+	uint16_t btnfilled = 0;
 	const EEU8_TCScore lrmax = EEU8_alignNucleotides<uint16_t>(profbuf, rf, rfd,
 					mat,
                                         iter, colstride, lastWordIdx,

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -2,6 +2,24 @@
  * Simple exerciser of aligner_swsse_ee_u8.cpp
  */
 
+// assumed CDNA where warp size is 64. 32 on Nvidia and RDNA
+#ifndef WARP_SIZE
+#define WARP_SIZE 64
+#endif
+
+#ifndef SSE_FAST_SCALAR
+ #ifndef E_PER_WARP
+  #define E_PER_WARP 2
+ #endif
+ #ifndef LANE_SIZE
+  #define LANE_SIZE 32 // number of lanes used in this
+ #endif
+#else // enabled SSE_FAST_SCALAR
+ #define E_PER_WARP 1
+ #define LANE_SIZE 1
+ #define MAX_QUERY_SIZE 604 // empirical value at the moment
+#endif // SSE_FAST_SCALAR
+
 #define SWSSE_INLINE_ONLY
 
 #include "../aligner_swsse_ee_u8.cpp"
@@ -101,12 +119,20 @@ int align_ee8_one(const int el, // for debuggging purpose
                 const int32_t ref_lrmax,
                 const int32_t ref_btnfilled) {
 	uint16_t btnfilled = 0;
+#ifndef SSE_FAST_SCALAR
 	const EEU8_TCScore lrmax = EEU8_alignNucleotides<uint16_t>(profbuf, rf, rfd,
 					mat,
                                         iter, colstride, lastWordIdx,
 					minsc, nrow,
 					btncand, btnfilled,
 					gaps[0],gaps[1],gaps[2],gaps[3]);
+#else
+	const EEU8_TCScore lrmax = EEU8_alignNucleotidesScalar<uint16_t>(profbuf, rf, rfd,
+                                        iter, colstride, lastWordIdx,
+					minsc, nrow,
+					btncand, btnfilled,
+					gaps[0],gaps[1],gaps[2],gaps[3]);
+#endif
 	int nerrs = 0;
 	if (int(ref_lrmax) != int(lrmax)) nerrs++;
 	if (int(ref_btnfilled) != int(btnfilled)) nerrs++;
@@ -162,7 +188,11 @@ int load_and_align_ee8(const int npar, const int nels) {
    int32_t *ref_lrmax = new int32_t[nels];
    int32_t *ref_btnfilled = new int32_t[nels];
    SSERegI *profbuf = new SSERegI[size_t(nels)*MAX_PB_EL];
+#ifndef FAST_SSE_SCALAR // matrix won't be used in fast scalar
    SSERegI *mat = new SSERegI[size_t(npar)*MAX_MAT_EL];
+#else
+   SSERegI *mat = nullptr;
+#endif
    char    *rf = new char[size_t(MAX_RF_EL)*nels];
    size_t  *nrow = new size_t[nels];
    size_t  *iter = new size_t[nels];

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -111,7 +111,6 @@ int align_ee8_one(const int el, // for debuggging purpose
 	// Note: The vast majority of reads have iter==151
 	if (iter!=151) return 0;  // TODO: We may properly use the right template function, or call slow align directly
 	const EEU8_TCScore lrmax = EEU8_alignNucleotidesScalar<uint16_t,151>(profbuf, rf, rfd,
-                                        iter, colstride, lastWordIdx,
 					nrow,
 					gaps[0],gaps[1],gaps[2],gaps[3]);
 #endif

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -108,7 +108,9 @@ int align_ee8_one(const int el, // for debuggging purpose
 					btncand, btnfilled,
 					gaps[0],gaps[1],gaps[2],gaps[3]);
 #else
-	const EEU8_TCScore lrmax = EEU8_alignNucleotidesScalar<uint16_t>(profbuf, rf, rfd,
+	// Note: The vast majority of reads have iter==151
+	if (iter!=151) return 0;  // TODO: We may properly use the right template function, or call slow align directly
+	const EEU8_TCScore lrmax = EEU8_alignNucleotidesScalar<uint16_t,151>(profbuf, rf, rfd,
                                         iter, colstride, lastWordIdx,
 					nrow,
 					gaps[0],gaps[1],gaps[2],gaps[3]);

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -100,7 +100,7 @@ int align_ee8_one(const int el, // for debuggging purpose
 		DpBtCandidate    *btncand,
                 const int32_t ref_lrmax,
                 const int32_t ref_btnfilled) {
-#ifndef SSE_FAST_SCALAR
+#ifndef PRE_LR_SCALAR
 	uint16_t btnfilled = 0;
 	const EEU8_TCScore lrmax = EEU8_alignNucleotides<uint16_t>(profbuf, rf, rfd,
 					mat,
@@ -117,7 +117,7 @@ int align_ee8_one(const int el, // for debuggging purpose
 #endif
 	int nerrs = 0;
 	if (int(ref_lrmax) != int(lrmax)) nerrs++;
-#ifndef SSE_FAST_SCALAR
+#ifndef PRE_LR_SCALAR
 	if (int(ref_btnfilled) != int(btnfilled)) nerrs++;
 #else
 	TAlScore sc = (TAlScore)(lrmax - 0xff);
@@ -125,13 +125,13 @@ int align_ee8_one(const int el, // for debuggging purpose
 #endif
 #ifndef NO_CHECK_PRINT
 	if (int(ref_lrmax) != int(lrmax)) fprintf(stderr, "[%i] MISMATCH in lrmax (%i != %i)\n",el,int(lrmax), int(ref_lrmax));
-#ifndef SSE_FAST_SCALAR
+#ifndef PRE_LR_SCALAR
 	if (int(ref_btnfilled) != int(btnfilled)) fprintf(stderr, "[%i] MISMATCH in ref_btnfilled (%i != %i)\n",el,int(btnfilled), int(ref_btnfilled));
 #else
 	if ((ref_btnfilled!=0) != (sc>=minsc)) fprintf(stderr, "[%i] MISMATCH in ref_btnfilled (%i) vs sc %i minsc %i)\n",el,int(ref_btnfilled), int(sc), int(minsc));
 #endif
 #endif
-	// TODO: In case of SSE_FAST_SCALAR, we should also likely want to test the complete align on the elements that need it
+	// TODO: In case of PRE_LR_SCALAR, we should also likely want to test the complete align on the elements that need it
 	//       But that's probably better done in a separate test
 	return nerrs;
 }

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -118,7 +118,6 @@ int align_ee8_one(const int el, // for debuggging purpose
 		DpBtCandidate    *btncand,
                 const int32_t ref_lrmax,
                 const int32_t ref_btnfilled) {
-	uint16_t btnfilled = 0;
 #ifndef SSE_FAST_SCALAR
 	const EEU8_TCScore lrmax = EEU8_alignNucleotides<uint16_t>(profbuf, rf, rfd,
 					mat,
@@ -129,17 +128,27 @@ int align_ee8_one(const int el, // for debuggging purpose
 #else
 	const EEU8_TCScore lrmax = EEU8_alignNucleotidesScalar<uint16_t>(profbuf, rf, rfd,
                                         iter, colstride, lastWordIdx,
-					minsc, nrow,
-					btncand, btnfilled,
+					nrow,
 					gaps[0],gaps[1],gaps[2],gaps[3]);
 #endif
 	int nerrs = 0;
 	if (int(ref_lrmax) != int(lrmax)) nerrs++;
+#ifndef SSE_FAST_SCALAR
 	if (int(ref_btnfilled) != int(btnfilled)) nerrs++;
+#else
+	TAlScore sc = (TAlScore)(lrmax - 0xff);
+	if ((ref_btnfilled!=0) != (sc>=minsc)) nerrs++;
+#endif
 #ifndef NO_CHECK_PRINT
 	if (int(ref_lrmax) != int(lrmax)) fprintf(stderr, "[%i] MISMATCH in lrmax (%i != %i)\n",el,int(lrmax), int(ref_lrmax));
+#ifndef SSE_FAST_SCALAR
 	if (int(ref_btnfilled) != int(btnfilled)) fprintf(stderr, "[%i] MISMATCH in ref_btnfilled (%i != %i)\n",el,int(btnfilled), int(ref_btnfilled));
+#else
+	if ((ref_btnfilled!=0) != (sc>=minsc)) fprintf(stderr, "[%i] MISMATCH in ref_btnfilled (%i) vs sc %i minsc %i)\n",el,int(ref_btnfilled), int(sc), int(minsc));
 #endif
+#endif
+	// TODO: In case of SSE_FAST_SCALAR, we should also likely want to test the complete align on the elements that need it
+	//       But that's probably better done in a separate test
 	return nerrs;
 }
 


### PR DESCRIPTION
Most alignment do not need the H,E,F vectors, just lrmax. And that can be computed much faster on the GPU, if we discard the vectors.

The exception is when (lmax-255)>minsc, but that happens only in a small fraction of the cases.

Adding the option of using this faster path... used in test setup only, for now.
Set PRE_LR_SCALAR macro to enable it.