### PR TITLE
2bit compressed pb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
 # GPU-enabled
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2 -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
 
 # Enable HIP. Use CXX=amdclang++ or CXX=hipcc 
 # Warning with hybrid OPENMP Compilations

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -506,7 +506,7 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
  *   rf      - reference sequence
  *
  */
-template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151>
+template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151, uint16_t MAX_RB=5>
 inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 					const char   rf[], const TIdxSize rfd,
 					const size_t nrow,
@@ -538,6 +538,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 		uint32_t val;
 	public:
 		constexpr TPackedScore() : val(0) {};
+		constexpr TPackedScore(const uint32_t packed_val) : val(packed_val) {};
 		// Note: j must be even
 		constexpr TPackedScore(const uint8_t *pvScore, const uint16_t j) { val = ((uint32_t *)(pvScore+(2*j)))[0]; }
 
@@ -548,6 +549,8 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 		constexpr uint8_t get_vs1_even() const {return uint8_t(val>>8); }
 		constexpr uint8_t get_vs0_odd() const {return uint8_t(val>>16); }
 		constexpr uint8_t get_vs1_odd() const {return uint8_t(val>>24); }
+
+		constexpr uint32_t operator()() const {return val;}
 	};
 
         class TPackedScoreHalf {
@@ -563,6 +566,8 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 
 		constexpr uint8_t get_vs0_even() const {return uint8_t(val); }
 		constexpr uint8_t get_vs1_even() const {return uint8_t(val>>8); }
+
+		constexpr uint16_t operator()() const {return val;}
 	};
 
         constexpr uint16_t iter = MAX_ITER;
@@ -584,6 +589,26 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 	assert_leq(readGapExtend, readGapOpen);
 	uint8_t rdgape = uint8_t(readGapExtend);
 
+	// Load the procbuf in local memeory
+	// as we will read over it many times
+	uint32_t loc_procbuf[MAX_RB][(MAX_ITER+1)/2];
+	for (int ir=0; ir<MAX_RB; ir++) {
+		size_t off = (size_t)( ir ) * iter * 2;
+		// points into the query profile
+		const uint8_t *pvScore = profbuf + off;
+		for(TIdxSize j = 0; j < ((iter-1)/2); j++) {
+			const TPackedScore full_score(pvScore,j*2);
+			loc_procbuf[ir][j] = full_score();
+		}
+		if constexpr((iter%2)!=0) {
+			// Last Even step
+		        const TPackedScoreHalf full_score(pvScore, iter-1);
+			loc_procbuf[ir][(iter-1)/2] = full_score();
+		}
+	}
+
+	//
+	//
 	// Maximum score in final row
 	EEU8_TCScore lrmax = MIN_U8;
 
@@ -607,9 +632,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 		
 		// Fetch the appropriate query profile.  Note that elements of rf must
 		// be numbers, not masks.
-		size_t off = (size_t)std::countr_zero( uint8_t(rf[i]) ) * iter * 2;
-		// points into the query profile
-		const uint8_t *pvScore = profbuf + off; // even elts = query profile, odd = gap barrier
+		const size_t ir = (size_t)std::countr_zero( uint8_t(rf[i]) );
 	
 		// scalar version of EEU8_alignOne()
 		{
@@ -628,11 +651,11 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 		  // Only downsides for the CPUs, that have fewer registers
 #pragma omp unroll full
 #endif
-		  for(TIdxSize j2 = 0; j2 < (iter-1); j2+=2) {
+		  for(TIdxSize j = 0; j < ((iter-1)/2); j++) {
 		    // Load cells from E and H, calculated previously
-		    TPackedEH full_eh(bufEH[j2/2]);
+		    TPackedEH full_eh(bufEH[j]);
 		    // Load the scores
-		    const TPackedScore full_score(pvScore,j2);
+		    const TPackedScore full_score(loc_procbuf[ir][j]);
 		    // Even step
 		    {
 		  	// Load cells from E and H, calculated previously
@@ -702,14 +725,15 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 			vh = vh_next;
 		    }
 		    // save the packed result back for the next i loop
-		    bufEH[j2/2] = full_eh;
+		    bufEH[j] = full_eh;
 		  }
 		  if constexpr((iter%2)!=0) {
 			// Last Even step
 		  	// Load cells from E and H, calculated previously
 			const TPackedEH full_eh(bufEH[iter/2]);
 		        // Load the scores
-		        const TPackedScoreHalf full_score(pvScore, iter-1);
+			// Use the Full Packed class for consistency
+		        const TPackedScore full_score(loc_procbuf[ir][(iter-1)/2]);
 
 			uint8_t ve = full_eh.get_E_even();
 			// no next round, do not need vh_next

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -535,39 +535,42 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 
         class TPackedScore {
 	private:
-		uint32_t val;
+		uint16_t val;
+		// Decode nibble: 0x0->0x00, 0x1->0x01, 0xf->0xff
+		static constexpr uint8_t decode4(uint8_t nibble) { return (nibble <= 1) ? nibble : 0xff; }
 	public:
 		constexpr TPackedScore() : val(0) {};
-		constexpr TPackedScore(const uint32_t packed_val) : val(packed_val) {};
-		// Note: j must be even
-		constexpr TPackedScore(const uint8_t *pvScore, const uint16_t j) { val = ((uint32_t *)(pvScore+(2*j)))[0]; }
+		constexpr TPackedScore(const uint16_t packed_val) : val(packed_val) {};
 
 		constexpr TPackedScore(const TPackedScore& other) : val(other.val) {}
 		constexpr TPackedScore& operator=(const TPackedScore& other) { val = other.val; return *this;}
 
-		constexpr uint8_t get_vs0_even() const {return uint8_t(val); }
-		constexpr uint8_t get_vs1_even() const {return uint8_t(val>>8); }
-		constexpr uint8_t get_vs0_odd() const {return uint8_t(val>>16); }
-		constexpr uint8_t get_vs1_odd() const {return uint8_t(val>>24); }
+		// low byte: even step; high byte: odd step; within each byte: low nibble=vs0, high nibble=vs1
+		constexpr uint8_t get_vs0_even() const { return decode4(uint8_t(val) & 0xf); }
+		constexpr uint8_t get_vs1_even() const { return decode4(uint8_t(val) >> 4); }
+		constexpr uint8_t get_vs0_odd()  const { return decode4(uint8_t(val >> 8) & 0xf); }
+		constexpr uint8_t get_vs1_odd()  const { return decode4(uint8_t(val >> 8) >> 4); }
 
-		constexpr uint32_t operator()() const {return val;}
+		constexpr uint16_t operator()() const {return val;}
 	};
 
         class TPackedScoreHalf {
 	private:
-		uint16_t val;
+		uint8_t val;
+		// Decode nibble: 0x0->0x00, 0x1->0x01, 0xf->0xff
+		static constexpr uint8_t decode4(uint8_t nibble) { return (nibble <= 1) ? nibble : 0xff; }
 	public:
 		constexpr TPackedScoreHalf() : val(0) {};
-		// Note: j must be even
-		constexpr TPackedScoreHalf(const uint8_t *pvScore, const uint16_t j) { val = ((uint16_t *)(pvScore+(2*j)))[0]; }
+		constexpr TPackedScoreHalf(const uint8_t packed_val) : val(packed_val) {};
 
 		constexpr TPackedScoreHalf(const TPackedScoreHalf& other) : val(other.val) {}
 		constexpr TPackedScoreHalf& operator=(const TPackedScoreHalf& other) { val = other.val; return *this;}
 
-		constexpr uint8_t get_vs0_even() const {return uint8_t(val); }
-		constexpr uint8_t get_vs1_even() const {return uint8_t(val>>8); }
+		// low nibble=vs0, high nibble=vs1 (even step only)
+		constexpr uint8_t get_vs0_even() const { return decode4(val & 0xf); }
+		constexpr uint8_t get_vs1_even() const { return decode4(val >> 4); }
 
-		constexpr uint16_t operator()() const {return val;}
+		constexpr uint8_t operator()() const {return val;}
 	};
 
         constexpr uint16_t iter = MAX_ITER;
@@ -589,21 +592,27 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 	assert_leq(readGapExtend, readGapOpen);
 	uint8_t rdgape = uint8_t(readGapExtend);
 
-	// Load the procbuf in local memeory
-	// as we will read over it many times
-	uint32_t loc_procbuf[MAX_RB][(MAX_ITER+1)/2];
+	// Load the procbuf into local memory, compacting {0x00,0x01,0xff} -> {0x0,0x1,0xf} nibbles.
+	// Each entry covers two consecutive j steps (even+odd): low byte=even, high byte=odd.
+	// Last entry (when iter is odd) uses only the low byte.
+	auto encode4 = [](uint8_t v) -> uint8_t { return (v <= 1) ? v : 0xf; };
+	auto pack_byte = [&](const uint8_t *p) -> uint8_t {
+		return encode4(p[0]) | (encode4(p[1]) << 4);
+	};
+	uint16_t loc_procbuf[MAX_RB][(MAX_ITER+1)/2];
 	for (int ir=0; ir<MAX_RB; ir++) {
 		size_t off = (size_t)( ir ) * iter * 2;
-		// points into the query profile
 		const uint8_t *pvScore = profbuf + off;
 		for(TIdxSize j = 0; j < ((iter-1)/2); j++) {
-			const TPackedScore full_score(pvScore,j*2);
-			loc_procbuf[ir][j] = full_score();
+			// Each j step occupies 2 bytes (vs0, vs1); even=j*2, odd=(j*2+2)
+			uint8_t even_byte = pack_byte(pvScore + j*4);      // vs0_even, vs1_even
+			uint8_t odd_byte  = pack_byte(pvScore + j*4 + 2);  // vs0_odd,  vs1_odd
+			loc_procbuf[ir][j] = uint16_t(even_byte) | (uint16_t(odd_byte) << 8);
 		}
 		if constexpr((iter%2)!=0) {
-			// Last Even step
-		        const TPackedScoreHalf full_score(pvScore, iter-1);
-			loc_procbuf[ir][(iter-1)/2] = full_score();
+			// Last Even step: only one j step remaining
+			uint8_t even_byte = pack_byte(pvScore + ((iter-1)/2)*4);
+			loc_procbuf[ir][(iter-1)/2] = uint16_t(even_byte);
 		}
 	}
 

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -535,30 +535,30 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 
         class TPackedScore {
 	private:
-		uint16_t val;
-		// Decode nibble: 0x0->0x00, 0x1->0x01, 0xf->0xff
-		static constexpr uint8_t decode4(uint8_t nibble) { return (nibble <= 1) ? nibble : 0xff; }
+		uint8_t val;
+		// Decode 2-bit field: 0->0x00, 1->0x01, 2->0xff
+		static constexpr uint8_t decode2(uint8_t bits) { return (bits <= 1) ? bits : 0xff; }
 	public:
 		constexpr TPackedScore() : val(0) {};
-		constexpr TPackedScore(const uint16_t packed_val) : val(packed_val) {};
+		constexpr TPackedScore(const uint8_t packed_val) : val(packed_val) {};
 
 		constexpr TPackedScore(const TPackedScore& other) : val(other.val) {}
 		constexpr TPackedScore& operator=(const TPackedScore& other) { val = other.val; return *this;}
 
-		// low byte: even step; high byte: odd step; within each byte: low nibble=vs0, high nibble=vs1
-		constexpr uint8_t get_vs0_even() const { return decode4(uint8_t(val) & 0xf); }
-		constexpr uint8_t get_vs1_even() const { return decode4(uint8_t(val) >> 4); }
-		constexpr uint8_t get_vs0_odd()  const { return decode4(uint8_t(val >> 8) & 0xf); }
-		constexpr uint8_t get_vs1_odd()  const { return decode4(uint8_t(val >> 8) >> 4); }
+		// bits[1:0]=vs0_even, bits[3:2]=vs1_even, bits[5:4]=vs0_odd, bits[7:6]=vs1_odd
+		constexpr uint8_t get_vs0_even() const { return decode2(val & 0x3); }
+		constexpr uint8_t get_vs1_even() const { return decode2((val >> 2) & 0x3); }
+		constexpr uint8_t get_vs0_odd()  const { return decode2((val >> 4) & 0x3); }
+		constexpr uint8_t get_vs1_odd()  const { return decode2((val >> 6) & 0x3); }
 
-		constexpr uint16_t operator()() const {return val;}
+		constexpr uint8_t operator()() const {return val;}
 	};
 
         class TPackedScoreHalf {
 	private:
 		uint8_t val;
-		// Decode nibble: 0x0->0x00, 0x1->0x01, 0xf->0xff
-		static constexpr uint8_t decode4(uint8_t nibble) { return (nibble <= 1) ? nibble : 0xff; }
+		// Decode 2-bit field: 0->0x00, 1->0x01, 2->0xff
+		static constexpr uint8_t decode2(uint8_t bits) { return (bits <= 1) ? bits : 0xff; }
 	public:
 		constexpr TPackedScoreHalf() : val(0) {};
 		constexpr TPackedScoreHalf(const uint8_t packed_val) : val(packed_val) {};
@@ -566,9 +566,9 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 		constexpr TPackedScoreHalf(const TPackedScoreHalf& other) : val(other.val) {}
 		constexpr TPackedScoreHalf& operator=(const TPackedScoreHalf& other) { val = other.val; return *this;}
 
-		// low nibble=vs0, high nibble=vs1 (even step only)
-		constexpr uint8_t get_vs0_even() const { return decode4(val & 0xf); }
-		constexpr uint8_t get_vs1_even() const { return decode4(val >> 4); }
+		// bits[1:0]=vs0_even, bits[3:2]=vs1_even (even step only)
+		constexpr uint8_t get_vs0_even() const { return decode2(val & 0x3); }
+		constexpr uint8_t get_vs1_even() const { return decode2((val >> 2) & 0x3); }
 
 		constexpr uint8_t operator()() const {return val;}
 	};
@@ -592,27 +592,29 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 	assert_leq(readGapExtend, readGapOpen);
 	uint8_t rdgape = uint8_t(readGapExtend);
 
-	// Load the procbuf into local memory, compacting {0x00,0x01,0xff} -> {0x0,0x1,0xf} nibbles.
-	// Each entry covers two consecutive j steps (even+odd): low byte=even, high byte=odd.
-	// Last entry (when iter is odd) uses only the low byte.
-	auto encode4 = [](uint8_t v) -> uint8_t { return (v <= 1) ? v : 0xf; };
-	auto pack_byte = [&](const uint8_t *p) -> uint8_t {
-		return encode4(p[0]) | (encode4(p[1]) << 4);
-	};
-	uint16_t loc_procbuf[MAX_RB][(MAX_ITER+1)/2];
-	for (int ir=0; ir<MAX_RB; ir++) {
-		size_t off = (size_t)( ir ) * iter * 2;
-		const uint8_t *pvScore = profbuf + off;
-		for(TIdxSize j = 0; j < ((iter-1)/2); j++) {
-			// Each j step occupies 2 bytes (vs0, vs1); even=j*2, odd=(j*2+2)
-			uint8_t even_byte = pack_byte(pvScore + j*4);      // vs0_even, vs1_even
-			uint8_t odd_byte  = pack_byte(pvScore + j*4 + 2);  // vs0_odd,  vs1_odd
-			loc_procbuf[ir][j] = uint16_t(even_byte) | (uint16_t(odd_byte) << 8);
-		}
-		if constexpr((iter%2)!=0) {
-			// Last Even step: only one j step remaining
-			uint8_t even_byte = pack_byte(pvScore + ((iter-1)/2)*4);
-			loc_procbuf[ir][(iter-1)/2] = uint16_t(even_byte);
+	// Load the procbuf into local memory, compacting {0x00,0x01,0xff} -> {0,1,2} (2-bit encoding).
+	// Each entry packs two consecutive j steps (even+odd) into one byte:
+	//   bits[1:0]=vs0_even, bits[3:2]=vs1_even, bits[5:4]=vs0_odd, bits[7:6]=vs1_odd
+	// Last entry (when iter is odd) uses only the low 4 bits (even step only).
+	uint8_t loc_procbuf[MAX_RB][(MAX_ITER+1)/2];
+	{
+		auto encode2 = [](uint8_t v) -> uint8_t { return (v <= 1) ? v : 2; };
+		for (int ir=0; ir<MAX_RB; ir++) {
+			size_t off = (size_t)( ir ) * iter * 2;
+			const uint8_t *pvScore = profbuf + off;
+			for(TIdxSize j = 0; j < ((iter-1)/2); j++) {
+				// Each j step occupies 2 bytes (vs0, vs1); even step at j*4, odd at j*4+2
+				const uint8_t *pe = pvScore + j*4;
+				loc_procbuf[ir][j] =  encode2(pe[0])        |
+									(encode2(pe[1]) << 2)   |
+									(encode2(pe[2]) << 4)   |
+									(encode2(pe[3]) << 6);
+			}
+			if constexpr((iter%2)!=0) {
+				// Last Even step: only one j step remaining
+				const uint8_t *pe = pvScore + ((iter-1)/2)*4;
+				loc_procbuf[ir][(iter-1)/2] = encode2(pe[0]) | (encode2(pe[1]) << 2);
+			}
 		}
 	}
 

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -493,7 +493,6 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
 	return lrmax;
 }
 
-
 /**
  * Like the previous alignNucleotides, but the Scalar version allows to forfeit some extra strutures.
  * Note that this version does not return the E, F, H vectors.
@@ -506,8 +505,267 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
  *   rf      - reference sequence
  *
  */
-template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151, uint16_t MAX_RB=5>
+template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151>
 inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
+					const char   rf[], const TIdxSize rfd,
+					const size_t nrow,
+					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
+        class TPackedEH {
+	private:
+		uint32_t val;
+	public:
+		constexpr TPackedEH() : val(0) {};
+		constexpr TPackedEH(const TPackedEH& other) : val(other.val) {}
+		constexpr TPackedEH& operator=(const TPackedEH& other) { val = other.val; return *this;}
+
+		constexpr void set(uint8_t E_even, uint8_t H_even, uint8_t E_odd, uint8_t H_odd) { val =(uint32_t(H_odd)<<24) | (uint32_t(E_odd)<<16) |  (uint32_t(H_even)<<8) | uint32_t(E_even);}
+		constexpr void set(uint8_t E_even, uint8_t H_even) { val = (uint32_t(H_even)<<8) | uint32_t(E_even);}
+
+		// preserve odd, update even (low 16 bits)
+		constexpr void set_even(uint8_t E, uint8_t H) { val = (val & uint32_t(0xffff0000U)) | ((uint32_t(H)<<8) | uint32_t(E));}
+		// preserve even, update odd (high 16 bits)
+		constexpr void set_odd(uint8_t E, uint8_t H) { val = (val & uint32_t(0xffffU)) | ((uint32_t(H)<<24) | (uint32_t(E)<<16));}
+
+		constexpr uint8_t get_E_even() const {return uint8_t(val); }
+		constexpr uint8_t get_H_even() const {return uint8_t(val>>8); }
+		constexpr uint8_t get_E_odd() const {return uint8_t(val>>16); }
+		constexpr uint8_t get_H_odd() const {return uint8_t(val>>24); }
+	};
+
+        class TPackedScore {
+	private:
+		uint32_t val;
+	public:
+		constexpr TPackedScore() : val(0) {};
+		// Note: j must be even
+		constexpr TPackedScore(const uint8_t *pvScore, const uint16_t j) { val = ((uint32_t *)(pvScore+(2*j)))[0]; }
+
+		constexpr TPackedScore(const TPackedScore& other) : val(other.val) {}
+		constexpr TPackedScore& operator=(const TPackedScore& other) { val = other.val; return *this;}
+
+		constexpr uint8_t get_vs0_even() const {return uint8_t(val); }
+		constexpr uint8_t get_vs1_even() const {return uint8_t(val>>8); }
+		constexpr uint8_t get_vs0_odd() const {return uint8_t(val>>16); }
+		constexpr uint8_t get_vs1_odd() const {return uint8_t(val>>24); }
+	};
+
+        class TPackedScoreHalf {
+	private:
+		uint16_t val;
+	public:
+		constexpr TPackedScoreHalf() : val(0) {};
+		// Note: j must be even
+		constexpr TPackedScoreHalf(const uint8_t *pvScore, const uint16_t j) { val = ((uint16_t *)(pvScore+(2*j)))[0]; }
+
+		constexpr TPackedScoreHalf(const TPackedScoreHalf& other) : val(other.val) {}
+		constexpr TPackedScoreHalf& operator=(const TPackedScoreHalf& other) { val = other.val; return *this;}
+
+		constexpr uint8_t get_vs0_even() const {return uint8_t(val); }
+		constexpr uint8_t get_vs1_even() const {return uint8_t(val>>8); }
+	};
+
+        constexpr uint16_t iter = MAX_ITER;
+
+	assert_gt(refGapOpen, 0);
+	uint8_t rfgapo = uint8_t(refGapOpen);
+	
+	// Set all elts to reference gap extension penalty
+	assert_gt(refGapExtend, 0);
+	assert_leq(refGapExtend, refGapOpen);
+	uint8_t rfgape = uint8_t(refGapExtend);
+
+	// Set all elts to read gap open penalty
+	assert_gt(readGapOpen, 0);
+	uint8_t rdgapo = uint8_t(readGapOpen);
+	
+	// Set all elts to read gap extension penalty
+	assert_gt(readGapExtend, 0);
+	assert_leq(readGapExtend, readGapOpen);
+	uint8_t rdgape = uint8_t(readGapExtend);
+
+	// Maximum score in final row
+	EEU8_TCScore lrmax = MIN_U8;
+
+	// Set all elts to reference gap open penalty
+	// iAutomatic initialize the H and E vectors in the first matrix column
+	TPackedEH bufEH[(iter+1)/2];
+
+	// Fill in the table as usual but instead of using the same gap-penalty
+	// vector for each iteration of the inner loop, load words out of a
+	// pre-calculated gap vector parallel to the query profile.  The pre-
+	// calculated gap vectors enforce the gap barrier constraint by making it
+	// infinitely costly to introduce a gap in barrier rows.
+	//
+	// AND use a separate loop to fill in the first row of the table, enforcing
+	// the st_ constraints in the process.  This is awkward because it
+	// separates the processing of the first row from the others and might make
+	// it difficult to use the first-row results in the next row, but it might
+	// be the simplest and least disruptive way to deal with the st_ constraint.
+
+	for(TIdxSize i = 0; i < rfd; i++) {
+		
+		// Fetch the appropriate query profile.  Note that elements of rf must
+		// be numbers, not masks.
+		size_t off = (size_t)std::countr_zero( uint8_t(rf[i]) ) * iter * 2;
+		// points into the query profile
+		const uint8_t *pvScore = profbuf + off; // even elts = query profile, odd = gap barrier
+	
+		// scalar version of EEU8_alignOne()
+		{
+		  // vhilsw: topmost (least sig) word set to 0xff, all other words=0
+		  uint8_t vhilsw   = 0xff;
+	
+		  // Set all cells to low value
+		  uint8_t vf       = 0;
+
+		  // in scalar mode, we always start high
+		  uint8_t vh = vhilsw; //0xff
+
+		  // For each character in the reference text
+#ifdef OMPGPU
+		  // Full unrolling allows bufEH to be mapped to the GPU register file
+		  // Only downsides for the CPUs, that have fewer registers
+#pragma omp unroll full
+#endif
+		  for(TIdxSize j2 = 0; j2 < (iter-1); j2+=2) {
+		    // Load cells from E and H, calculated previously
+		    TPackedEH full_eh(bufEH[j2/2]);
+		    // Load the scores
+		    const TPackedScore full_score(pvScore,j2);
+		    // Even step
+		    {
+		  	// Load cells from E and H, calculated previously
+			uint8_t ve = full_eh.get_E_even();
+		  	uint8_t vh_next = full_eh.get_H_even();
+
+			// Store cells in F, calculated previously
+			vf = subs_u8(vf, full_score.get_vs1_even()); // veto some ref gap extensions
+		  	
+		  	// Factor in query profile (matches and mismatches)
+		  	vh = subs_u8(vh, full_score.get_vs0_even());
+		  	
+		  	// Update H, factoring in E and F
+		  	vh = std::max(vh, ve);
+		  	vh = std::max(vh, vf);
+		  	
+		  	// Save the new vH values
+		  	uint8_t vtmp = vh;
+		  	
+		  	// Update vE value
+		  	vh = subs_u8(vh, rdgapo);
+		  	vh = subs_u8(vh, full_score.get_vs1_even()); // veto some read gap opens
+		  	ve = subs_u8(ve, rdgape);
+		  	ve = std::max(ve, vh);
+
+		  	// Save E and H values for next i round
+		  	full_eh.set_even(ve,vtmp);
+		  	
+		  	// Update vf value for next round
+		  	vtmp = subs_u8(vtmp, rfgapo);
+		  	vf = subs_u8(vf, rfgape);
+		  	vf = std::max(vf, vtmp);
+			vh = vh_next;
+		    }
+		    // Odd step
+		    {
+		  	// Load cells from E and H, calculated previously
+			uint8_t ve = full_eh.get_E_odd();
+		  	uint8_t vh_next = full_eh.get_H_odd();
+
+			// Store cells in F, calculated previously
+			vf = subs_u8(vf, full_score.get_vs1_odd()); // veto some ref gap extensions
+		  	
+		  	// Factor in query profile (matches and mismatches)
+		  	vh = subs_u8(vh, full_score.get_vs0_odd());
+		  	
+		  	// Update H, factoring in E and F
+		  	vh = std::max(vh, ve);
+		  	vh = std::max(vh, vf);
+		  	
+		  	// Save the new vH values
+		  	uint8_t vtmp = vh;
+		  	
+		  	// Update vE value
+		  	vh = subs_u8(vh, rdgapo);
+		  	vh = subs_u8(vh, full_score.get_vs1_odd()); // veto some read gap opens
+		  	ve = subs_u8(ve, rdgape);
+		  	ve = std::max(ve, vh);
+
+		  	// Save E and H values for next i round
+		  	full_eh.set_odd(ve,vtmp);
+		  	
+		  	// Update vf value for next round
+		  	vtmp = subs_u8(vtmp, rfgapo);
+		  	vf = subs_u8(vf, rfgape);
+		  	vf = std::max(vf, vtmp);
+			vh = vh_next;
+		    }
+		    // save the packed result back for the next i loop
+		    bufEH[j2/2] = full_eh;
+		  }
+		  if constexpr((iter%2)!=0) {
+			// Last Even step
+		  	// Load cells from E and H, calculated previously
+			const TPackedEH full_eh(bufEH[iter/2]);
+		        // Load the scores
+		        const TPackedScoreHalf full_score(pvScore, iter-1);
+
+			uint8_t ve = full_eh.get_E_even();
+			// no next round, do not need vh_next
+
+			// Store cells in F, calculated previously
+			vf = subs_u8(vf, full_score.get_vs1_even()); // veto some ref gap extensions
+		  	
+		  	// Factor in query profile (matches and mismatches)
+		  	vh = subs_u8(vh, full_score.get_vs0_even());
+		  	
+		  	// Update H, factoring in E and F
+		  	vh = std::max(vh, ve);
+		  	vh = std::max(vh, vf);
+		  	
+		  	// Save the new vH values
+		  	uint8_t vtmp = vh;
+		  	
+		  	// Update vE value
+		  	vh = subs_u8(vh, rdgapo);
+		  	vh = subs_u8(vh, full_score.get_vs1_even()); // veto some read gap opens
+		  	ve = subs_u8(ve, rdgape);
+		  	ve = std::max(ve, vh);
+
+		  	// Save E and H values for next i round
+		  	bufEH[iter/2].set(ve,vtmp);
+		  	
+		  	// no next round
+		  }
+		}
+
+		// Note: we may not want to extract from the final row
+		//       EEU8_TCScore == uint8_t == uint8_t
+		// Was: EEU8_TCScore lr = bufEH2[iter - 1].get_H();
+		EEU8_TCScore lr = ((iter%2)!=0) ? bufEH[iter/2].get_H_even() : bufEH[(iter-1)/2].get_H_odd();
+		if(lr > lrmax) {
+			lrmax = lr;
+		}
+	}
+
+	return lrmax;
+}
+
+/**
+ * Like the previous alignNucleotides, but the Scalar version allows to forfeit some extra strutures.
+ * Note that this version does not return the E, F, H vectors.
+ * Only lrmax is computed and returned.
+ * Profbuf compacted and saved into a local structure, encoded into 2 bits for values of masking.
+ *
+ * If the vectors are needed, e.g. when (lrmax - 0xff)>=minsc, i.e. btnfilled>0, use the regular, full version.
+ *
+ * Select intput parameters:
+ *   profbuf - buffer for query profile & temp vecs
+ *   rf      - reference sequence
+ *
+ */
+template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151, uint16_t MAX_RB=5>
+inline EEU8_TCScore EEU8_alignNucleotidesLRM11Scalar(const uint8_t profbuf[],
 					const char   rf[], const TIdxSize rfd,
 					const size_t nrow,
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
@@ -550,25 +808,6 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 		constexpr uint8_t get_vs1_even() const { return decode2((val >> 2) & 0x3); }
 		constexpr uint8_t get_vs0_odd()  const { return decode2((val >> 4) & 0x3); }
 		constexpr uint8_t get_vs1_odd()  const { return decode2((val >> 6) & 0x3); }
-
-		constexpr uint8_t operator()() const {return val;}
-	};
-
-        class TPackedScoreHalf {
-	private:
-		uint8_t val;
-		// Decode 2-bit field: 0->0x00, 1->0x01, 2->0xff
-		static constexpr uint8_t decode2(uint8_t bits) { return (bits <= 1) ? bits : 0xff; }
-	public:
-		constexpr TPackedScoreHalf() : val(0) {};
-		constexpr TPackedScoreHalf(const uint8_t packed_val) : val(packed_val) {};
-
-		constexpr TPackedScoreHalf(const TPackedScoreHalf& other) : val(other.val) {}
-		constexpr TPackedScoreHalf& operator=(const TPackedScoreHalf& other) { val = other.val; return *this;}
-
-		// bits[1:0]=vs0_even, bits[3:2]=vs1_even (even step only)
-		constexpr uint8_t get_vs0_even() const { return decode2(val & 0x3); }
-		constexpr uint8_t get_vs1_even() const { return decode2((val >> 2) & 0x3); }
 
 		constexpr uint8_t operator()() const {return val;}
 	};

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -111,10 +111,17 @@ int align_ee8_one(const int el, // for debuggging purpose
 #else
 	// Note: The vast majority of reads have iter==151
 	if (iter!=151) return 0;  // TODO: We may properly use the right template function, or call slow align directly
+#ifndef PBMASK
 	const EEU8_TCScore lrmax = EEU8_alignNucleotidesLRScalar<uint16_t,151>(profbuf, rf, rfd,
 					nrow,
 					gaps[0],gaps[1],gaps[2],gaps[3]);
-#endif
+
+#else
+	const EEU8_TCScore lrmax = EEU8_alignNucleotidesLRM11Scalar<uint16_t,151>(profbuf, rf, rfd,
+					nrow,
+					gaps[0],gaps[1],gaps[2],gaps[3]);
+#endif // PBMASK
+#endif // PR_LR_SCALAR
 	int nerrs = 0;
 	if (int(ref_lrmax) != int(lrmax)) nerrs++;
 #ifndef PRE_LR_SCALAR


### PR DESCRIPTION
Add EEU8_alignNucleotidesLRM11Scalar function, which is a variant of EEU8_alignNucleotidesLRScalar that assumes that all values in profbuf are either 0, 1, of 0xff.
This happens to be true when --mp "1,1" is used.

Using that assumption, we pack those values into a local buffer, using a 2-bit encoding, which makes that buffer 4x smaller.