### PR TITLE
Split OMPGPU loop between CUs and threads, mimicking CPU logic in the test program

### DIFF
--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -161,12 +161,15 @@ void align_ee8(const int npar, const int nels,
    const int elp_pp = (nels+ (npar-1))/npar; // round up
    int nerrs = 0;
 #ifdef OMPGPU
-#pragma omp target teams distribute parallel for reduction(+:nerrs)
+#pragma omp target teams distribute reduction(+:nerrs)
 #else
 #pragma omp parallel for schedule(dynamic) reduction(+:nerrs)
 #endif
    for (int p=0; p<npar; p++) {
       const int iend = std::min((p+1)*elp_pp,nels);
+#ifdef OMPGPU
+#pragma omp parallel for reduction(+:nerrs)
+#endif
       for (int i=p*elp_pp; i<iend; i++) {
          nerrs+= align_ee8_one(i,
 		nrow[i], iter[i], colstride[i], lastWordIdx[i],minsc[i], rfd[i],


### PR DESCRIPTION
Seems to be beneficial for this function.

Changed semantics of npar to be simply correlated with GPU CUs, similarly to the CPU version.
(Before it was tied to number of threads)
