### PR TITLE
Add EEU8_alignNucleotidesVect, enabled with CPUVECT macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ CXX := amdclang++
 # CPU-only
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DCPUVECT -DNO_CHECK_PRINT
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DCPUVECT -DNO_CHECK_PRINT -march=native
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR
 CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
 

--- a/Makefile
+++ b/Makefile
@@ -52,12 +52,13 @@ CXX := amdclang++
 # CPU-only
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DCPUVECT -DNO_CHECK_PRINT
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR
 CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
 
 #
 # GPU-enabled
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm  -Rpass-analysis=kernel-resource-usage
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
 

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,18 @@ BOWTIE_SHARED_MEM :=
 
 #
 # Recommended amdclang++ flags
+#
+# Note: Needs at least version 22.0
+#       Older versions have broken builtin sat_sub
+#       Tested with container
+#       docker:rocm/dev-ubuntu-24.04:7.2.4
+#
 CXX := amdclang++
 # amdclang++ can use hipcc to compile hip kernels anyways with -x hip
 # CXX := hipcc
 
 # CPU-only
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR
 CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -344,6 +344,93 @@ inline void EEU8_lazyF(const SSERegI vf0,
 }
 #endif
 
+#ifndef BUILTIN_SUB_SAT_BROKEN
+/*
+ * Like EEU8_alignOne, but assuming scalar processing and going over many elements at once
+ *
+ * Note: TBuf must be the same width as vectu8_t
+ *
+ */
+
+template<int VLen, typename TIdxSize, typename TBuf>
+inline uint8_t __attribute__((ext_vector_type(VLen))) EEU8_alignVect(
+			const TIdxSize iter,
+			const size_t colstride,
+			const TBuf *pvScore,
+			const TBuf *pvHLoad, const TBuf *pvELoad,
+			TBuf *pvHStore, TBuf *pvEStore, TBuf *pvFStore,
+			const uint8_t rfgapo, const uint8_t rfgape, const uint8_t rdgapo, const uint8_t rdgape) {
+		typedef uint8_t vectu8_t __attribute__((ext_vector_type(VLen)));
+		// the gaps are the same for all the elements
+		// pre-load in vector format
+		const vectu8_t vect_rfgapo = rfgapo;
+		const vectu8_t vect_rfgape = rfgape;
+		const vectu8_t vect_rdgapo = rdgapo;
+		const vectu8_t vect_rdgape = rdgape;
+
+		// vhilsw: Set all to 0xff
+		vectu8_t vhilsw   = 0xff;
+	
+		// Set all cells to low value
+		vectu8_t vf       = 0;
+
+		// in scalar mode, we always start high
+		vectu8_t vh = vhilsw; //0xff
+		
+		// For each character in the reference text:
+		for(TIdxSize j = 0; j < iter; j++) {
+			vectu8_t vs0 = *pvScore;
+                        pvScore++;
+			vectu8_t vs1 = *pvScore;
+                        pvScore++;
+			// Load cells from E, calculated previously
+			vectu8_t ve = *pvELoad;
+			pvELoad += ROWSTRIDE;
+			
+			// Store cells in F, calculated previously
+			vf = __builtin_elementwise_sub_sat(vf, vs1); // veto some ref gap extensions
+			// HACK: Remove explicit cast
+			*((vectu8_t*)pvFStore) = vf;
+			pvFStore += ROWSTRIDE;
+			
+			// Factor in query profile (matches and mismatches)
+			vh = __builtin_elementwise_sub_sat(vh, vs0);
+			
+			// Update H, factoring in E and F
+			vh = __builtin_elementwise_max(vh, ve);
+			vh = __builtin_elementwise_max(vh, vf);
+			
+			// Save the new vH values
+			// HACK: Remove explicit cast
+			*((vectu8_t*)pvHStore) = vh;
+			pvHStore += ROWSTRIDE;
+			
+			// Update vE value
+			vectu8_t vtmp = vh;
+			vh = __builtin_elementwise_sub_sat(vh, vect_rdgapo);
+			vh = __builtin_elementwise_sub_sat(vh, vs1); // veto some read gap opens
+			ve = __builtin_elementwise_sub_sat(ve, vect_rdgape);
+			ve = __builtin_elementwise_max(ve, vh);
+
+			// Load the next h value
+			vh = *pvHLoad;
+			pvHLoad += ROWSTRIDE;
+			
+			// Save E values
+			// HACK: Remove explicit cast
+			*((vectu8_t*)pvEStore) = ve;
+			pvEStore += ROWSTRIDE;
+			
+			// Update vf value
+			vtmp = __builtin_elementwise_sub_sat(vtmp, vect_rfgapo);
+			vf = __builtin_elementwise_sub_sat(vf, vect_rfgape);
+			vf = __builtin_elementwise_max(vf, vtmp);
+		}
+
+		return vf;
+}
+#endif
+
 /**
  * Solve the current alignment problem using SSE instructions that operate on 16
  * unsigned 8-bit values packed into a single 128-bit register.

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -353,7 +353,7 @@ inline void EEU8_lazyF(const SSERegI vf0,
  */
 
 template<int VLen, typename TIdxSize, typename TBuf>
-inline uint8_t __attribute__((ext_vector_type(VLen))) EEU8_alignVect(
+inline void EEU8_alignVect(
 			const TIdxSize iter,
 			const size_t colstride,
 			const TBuf *pvScore,
@@ -426,8 +426,6 @@ inline uint8_t __attribute__((ext_vector_type(VLen))) EEU8_alignVect(
 			vf = __builtin_elementwise_sub_sat(vf, vect_rfgape);
 			vf = __builtin_elementwise_max(vf, vtmp);
 		}
-
-		return vf;
 }
 #endif
 

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -387,18 +387,18 @@ inline void EEU8_alignVect(
 			// We expect VLen>>5, so there is high probabilty all 5 will be needed
 			// So, we always load all 5 of them
 			// Using chained ternary operator logic, since that resolves to masked vector operations
-			vectu8_t vs0 = pvScore[j*2];
-			vs0 = (rfidxs==1) ? pvScore[2*iter+ j*2] : vs0;
-			vs0 = (rfidxs==2) ? pvScore[4*iter+ j*2] : vs0;
-			vs0 = (rfidxs==3) ? pvScore[6*iter+ j*2] : vs0;
-			vs0 = (rfidxs==4) ? pvScore[8*iter+ j*2] : vs0;
+			uint64_t pvScore_idx = j*5*2;
+			vectu8_t vs0 = pvScore[pvScore_idx];
+			vs0 = (rfidxs==1) ? pvScore[pvScore_idx+1] : vs0;
+			vs0 = (rfidxs==2) ? pvScore[pvScore_idx+2] : vs0;
+			vs0 = (rfidxs==3) ? pvScore[pvScore_idx+3] : vs0;
+			vs0 = (rfidxs==4) ? pvScore[pvScore_idx+4] : vs0;
 
-			vectu8_t vs1 = pvScore[j*2+1];
-			vs1 = (rfidxs==1) ? pvScore[2*iter+ j*2+1] : vs1;
-			vs1 = (rfidxs==2) ? pvScore[4*iter+ j*2+1] : vs1;
-			vs1 = (rfidxs==3) ? pvScore[6*iter+ j*2+1] : vs1;
-			vs1 = (rfidxs==4) ? pvScore[8*iter+ j*2+1] : vs1;
-
+			vectu8_t vs1 = pvScore[pvScore_idx+5];
+			vs1 = (rfidxs==1) ? pvScore[pvScore_idx+6] : vs1;
+			vs1 = (rfidxs==2) ? pvScore[pvScore_idx+7] : vs1;
+			vs1 = (rfidxs==3) ? pvScore[pvScore_idx+8] : vs1;
+			vs1 = (rfidxs==4) ? pvScore[pvScore_idx+9] : vs1;
 
 			// Load cells from E, calculated previously
 			vectu8_t ve = *pvELoad;
@@ -720,6 +720,7 @@ inline EEU8_Vector<uint8_t, VLen> EEU8_alignNucleotidesVect(
 		// Fetch the appropriate query profiles.  Note that elements of rf must
 		// be numbers, not masks.
 		vectu8_t rfidxs = __builtin_elementwise_ctzg(rf[i]);
+
 		// points into the base query profile
 		const vectu8_t *pvScore = profbuf;
 	

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -88,6 +88,11 @@ constexpr uint8_t subs_u8(uint8_t a, uint8_t b) {
 #endif
 }
 
+#ifndef BUILTIN_SUB_SAT_BROKEN
+template <typename T, unsigned int N>
+using EEU8_Vector = T __attribute__((ext_vector_type(N)));
+#endif
+
 /**
  * Build query profile look up tables for the read.  The query profile look
  * up table is organized as a 1D array indexed by [i][j] where i is the
@@ -352,15 +357,15 @@ inline void EEU8_lazyF(const SSERegI vf0,
  *
  */
 
-template<int VLen, typename TIdxSize, typename TBuf>
+template<unsigned int VLen, typename TIdxSize, typename TBuf>
 inline void EEU8_alignVect(
 			const TIdxSize iter,
 			const size_t colstride,
-			const TBuf *pvScore, const uint8_t __attribute__((ext_vector_type(VLen))) rfidxs,
+			const TBuf *pvScore, const EEU8_Vector<uint8_t, VLen> rfidxs,
 			const TBuf *pvHLoad, const TBuf *pvELoad,
 			TBuf *pvHStore, TBuf *pvEStore, TBuf *pvFStore,
 			const uint8_t rfgapo, const uint8_t rfgape, const uint8_t rdgapo, const uint8_t rdgape) {
-		typedef uint8_t vectu8_t __attribute__((ext_vector_type(VLen)));
+		typedef EEU8_Vector<uint8_t, VLen> vectu8_t;
 		// the gaps are the same for all the elements
 		// pre-load in vector format
 		const vectu8_t vect_rfgapo = rfgapo;
@@ -607,16 +612,16 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
  *
  */
 
-template<int VLen, typename TIdxSize>
-inline EEU8_TCScore __attribute__((ext_vector_type(VLen)))  EEU8_alignNucleotidesVect(
-					const uint8_t __attribute__((ext_vector_type(VLen))) profbuf[],
-					const uint8_t __attribute__((ext_vector_type(VLen))) rf[], const TIdxSize rfd,
-					uint8_t __attribute__((ext_vector_type(VLen))) pmat[],
+template<unsigned int VLen, typename TIdxSize>
+inline EEU8_Vector<uint8_t, VLen> EEU8_alignNucleotidesVect(
+					const EEU8_Vector<uint8_t, VLen> profbuf[],
+					const EEU8_Vector<uint8_t, VLen> rf[], const TIdxSize rfd,
+					EEU8_Vector<uint8_t, VLen> pmat[],
 					const TIdxSize iter, const size_t colstride, const size_t lastWordIdx,
 					const TAlScore minsc, const size_t nrow,
 					DpBtCandidate btncand[], TIdxSize btnfilled[],
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
-	typedef uint8_t vectu8_t __attribute__((ext_vector_type(VLen)));
+	typedef EEU8_Vector<uint8_t, VLen> vectu8_t;
 
 	// Many thanks to Michael Farrar for releasing his striped Smith-Waterman
 	// implementation:

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -356,7 +356,7 @@ template<int VLen, typename TIdxSize, typename TBuf>
 inline void EEU8_alignVect(
 			const TIdxSize iter,
 			const size_t colstride,
-			const TBuf *pvScore,
+			const TBuf *pvScore, const uint8_t __attribute__((ext_vector_type(VLen))) rfidxs,
 			const TBuf *pvHLoad, const TBuf *pvELoad,
 			TBuf *pvHStore, TBuf *pvEStore, TBuf *pvFStore,
 			const uint8_t rfgapo, const uint8_t rfgape, const uint8_t rdgapo, const uint8_t rdgape) {
@@ -379,18 +379,29 @@ inline void EEU8_alignVect(
 		
 		// For each character in the reference text:
 		for(TIdxSize j = 0; j < iter; j++) {
-			vectu8_t vs0 = *pvScore;
-                        pvScore++;
-			vectu8_t vs1 = *pvScore;
-                        pvScore++;
+			// We expect VLen>>5, so there is high probabilty all 5 will be needed
+			// So, we always load all 5 of them
+			// Using chained ternary operator logic, since that resolves to masked vector operations
+			vectu8_t vs0 = pvScore[j*2];
+			vs0 = (rfidxs==1) ? pvScore[2*iter+ j*2] : vs0;
+			vs0 = (rfidxs==2) ? pvScore[4*iter+ j*2] : vs0;
+			vs0 = (rfidxs==3) ? pvScore[6*iter+ j*2] : vs0;
+			vs0 = (rfidxs==4) ? pvScore[8*iter+ j*2] : vs0;
+
+			vectu8_t vs1 = pvScore[j*2+1];
+			vs1 = (rfidxs==1) ? pvScore[2*iter+ j*2+1] : vs1;
+			vs1 = (rfidxs==2) ? pvScore[4*iter+ j*2+1] : vs1;
+			vs1 = (rfidxs==3) ? pvScore[6*iter+ j*2+1] : vs1;
+			vs1 = (rfidxs==4) ? pvScore[8*iter+ j*2+1] : vs1;
+
+
 			// Load cells from E, calculated previously
 			vectu8_t ve = *pvELoad;
 			pvELoad += ROWSTRIDE;
 			
 			// Store cells in F, calculated previously
 			vf = __builtin_elementwise_sub_sat(vf, vs1); // veto some ref gap extensions
-			// HACK: Remove explicit cast
-			*((vectu8_t*)pvFStore) = vf;
+			*pvFStore = vf;
 			pvFStore += ROWSTRIDE;
 			
 			// Factor in query profile (matches and mismatches)
@@ -401,8 +412,7 @@ inline void EEU8_alignVect(
 			vh = __builtin_elementwise_max(vh, vf);
 			
 			// Save the new vH values
-			// HACK: Remove explicit cast
-			*((vectu8_t*)pvHStore) = vh;
+			*pvHStore = vh;
 			pvHStore += ROWSTRIDE;
 			
 			// Update vE value
@@ -417,8 +427,7 @@ inline void EEU8_alignVect(
 			pvHLoad += ROWSTRIDE;
 			
 			// Save E values
-			// HACK: Remove explicit cast
-			*((vectu8_t*)pvEStore) = ve;
+			*pvEStore = ve;
 			pvEStore += ROWSTRIDE;
 			
 			// Update vf value
@@ -589,6 +598,166 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
 	btnfilled_ = btnfilled;  // pass it out
 	return lrmax;
 }
+
+#ifndef BUILTIN_SUB_SAT_BROKEN
+/*
+ * Like EEU8_alignNucleotides, but assuming scalar processing and going over many elements at once
+ *
+ * Note: TBuf must be the same width as vectu8_t
+ *
+ */
+
+template<int VLen, typename TIdxSize>
+inline EEU8_TCScore __attribute__((ext_vector_type(VLen)))  EEU8_alignNucleotidesVect(
+					const uint8_t __attribute__((ext_vector_type(VLen))) profbuf[],
+					const uint8_t __attribute__((ext_vector_type(VLen))) rf[], const TIdxSize rfd,
+					uint8_t __attribute__((ext_vector_type(VLen))) pmat[],
+					const TIdxSize iter, const size_t colstride, const size_t lastWordIdx,
+					const TAlScore minsc, const size_t nrow,
+					DpBtCandidate btncand[], TIdxSize btnfilled[],
+					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
+	typedef uint8_t vectu8_t __attribute__((ext_vector_type(VLen)));
+
+	// Many thanks to Michael Farrar for releasing his striped Smith-Waterman
+	// implementation:
+	//
+	//  http://sites.google.com/site/farrarmichael/smith-waterman
+	//
+	// Much of the implmentation below is adapted from Michael's code.
+
+	// Set to reference gap open penalty
+	uint8_t rfgapo   = 0;
+	uint8_t rfgape   = 0;
+	uint8_t rdgapo   = 0;
+	uint8_t rdgape   = 0;
+
+	assert_gt(refGapOpen, 0);
+	rfgapo = refGapOpen;
+	
+	// Set to reference gap extension penalty
+	assert_gt(refGapExtend, 0);
+	assert_leq(refGapExtend, refGapOpen);
+	rfgape = refGapExtend;
+
+	// Set to read gap open penalty
+	assert_gt(readGapOpen, 0);
+	rdgapo = readGapOpen;
+	
+	// Set to read gap extension penalty
+	assert_gt(readGapExtend, 0);
+	assert_leq(readGapExtend, readGapOpen);
+	rdgape = readGapExtend;
+
+	// Points to a long vector of vectu8_t where each element is a block of
+	// contiguous cells in the E, F or H matrix.  If the index % 3 == 0, then
+	// the block of cells is from the E matrix.  If index % 3 == 1, they're
+	// from the F matrix.  If index % 3 == 2, then they're from the H matrix.
+	// Blocks of cells are organized in the same interleaved manner as they are
+	// calculated by the Farrar algorithm.
+	// const SSERegI *pvScore; // points into the query profile
+
+	assert_eq(ROWSTRIDE, colstride / iter);
+
+	// Initialize the H and E vectors in the first matrix column
+	{
+	  vectu8_t *pvHTmp = pmat + SSEMatrixConsts::TMP;
+	  vectu8_t *pvETmp = pmat + SSEMatrixConsts::E;
+	  vectu8_t vlo      = 0;
+	
+	  for(size_t i = 0; i < iter; i++) {
+		*pvETmp = vlo;
+		*pvHTmp = vlo;  // start high in end-to-end mode
+		pvETmp += ROWSTRIDE;
+		pvHTmp += ROWSTRIDE;
+	  }
+	}
+
+	// These are swapped just before the innermost loop
+	vectu8_t *pvHLoad  = pmat + SSEMatrixConsts::TMP;
+	vectu8_t *pvHStore = pmat + SSEMatrixConsts::H;
+	vectu8_t *pvELoad  = pmat + SSEMatrixConsts::E;
+	vectu8_t *pvEStore = pmat + colstride + SSEMatrixConsts::E;
+	vectu8_t *pvFStore = pmat + SSEMatrixConsts::F;
+	
+	// sc := lr - 0xff
+	// minlr = minsc + 0xff
+	// Make it fit inside uint8_t
+	const uint8_t minlr = 
+		(minsc<=(-255)) 
+		? 0                 // underflow
+		: ((minsc>0) 
+			? 0xff      // overflow
+			: (minsc + 0xff)
+		  );
+
+	// Maximum score in final row
+	// Reminder: EEU8_TCScore==uint8_t
+	vectu8_t lrmax = MIN_U8;
+
+	for (int i=0; i<VLen; i++) btnfilled[i] = 0;
+
+	// Fill in the table as usual but instead of using the same gap-penalty
+	// vector for each iteration of the inner loop, load words out of a
+	// pre-calculated gap vector parallel to the query profile.  The pre-
+	// calculated gap vectors enforce the gap barrier constraint by making it
+	// infinitely costly to introduce a gap in barrier rows.
+	//
+	// AND use a separate loop to fill in the first row of the table, enforcing
+	// the st_ constraints in the process.  This is awkward because it
+	// separates the processing of the first row from the others and might make
+	// it difficult to use the first-row results in the next row, but it might
+	// be the simplest and least disruptive way to deal with the st_ constraint.
+
+	for(TIdxSize i = 0; i < rfd; i++) {
+		assert(pvFStore == (pmat + i*colstride + SSEMatrixConsts::F));
+		assert(pvHStore == (pmat + i*colstride + SSEMatrixConsts::H));
+		
+		// Fetch the appropriate query profiles.  Note that elements of rf must
+		// be numbers, not masks.
+		vectu8_t rfidxs = __builtin_elementwise_ctzg(rf[i]);
+		// points into the base query profile
+		const vectu8_t *pvScore = profbuf;
+	
+		EEU8_alignVect<VLen>(iter,
+                        	colstride,
+                        	pvScore, rfidxs,
+                        	pvHLoad, pvELoad,
+                        	pvHStore, pvEStore, pvFStore,
+                        	rfgapo, rfgape, rdgapo, rdgape);
+
+		// else, no need for lazyF
+		pvHLoad = pvHStore;    // new pvHLoad = pvHStore
+		
+		// Note: we may not want to extract from the final row
+		vectu8_t lr = pvHLoad[lastWordIdx];
+		lrmax = __builtin_elementwise_max(lr,lrmax);
+		if (__builtin_reduce_max(lr) >= minlr) {
+		   // At least one triggered, let's see which one.
+		   for (int i=0; i<VLen; i++) {
+		      const uint8_t lr_i = lr[i];
+		      if (lr_i >= minlr) { 
+			// Yes, this is legit
+
+			// Note: The ordering is different than in EEU8_alignNucleotides
+			btncand[i+btnfilled[i]*VLen].init(nrow-1, i, lr_i);
+			btnfilled[i]++;
+		      }
+		   }
+		}
+
+		// pvHLoad are already where they need to be
+		
+		// Adjust the load and store vectors here.  
+		pvHStore = pvHStore + colstride;
+		pvELoad  = pvELoad  + colstride;
+		pvEStore = pvEStore + colstride;
+		pvFStore = pvFStore + colstride;
+	}
+
+
+	return lrmax;
+}
+#endif
 
 /**
  * Like the previous alignNucleotides, but the Scalar version allows to forfeit some extra strutures.

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -81,7 +81,11 @@ typedef uint8_t EEU8_TCScore;
 // Helper for saturating subtraction (unsigned 8-bit)
 // since there is no such thing in standard C++.
 constexpr uint8_t subs_u8(uint8_t a, uint8_t b) {
+#ifndef BUILTIN_SUB_SAT_BROKEN
+    return __builtin_elementwise_sub_sat(a,b);
+#else
     return a-std::min(a,b);
+#endif
 }
 
 /**

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -511,6 +511,17 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
 	SSERegI *pvEStore = pmat + colstride + SSEMatrixConsts::E;
 	SSERegI *pvFStore = pmat + SSEMatrixConsts::F;
 	
+	// sc := lr - 0xff
+	// minlr = minsc + 0xff
+	// Make it fit inside uint8_t
+	const EEU8_TCScore minlr = 
+		(minsc<=(-255)) 
+		? 0                 // underflow
+		: ((minsc>0) 
+			? 0xff      // overflow
+			: (minsc + 0xff)
+		  );
+
 	// Maximum score in final row
 	EEU8_TCScore lrmax = MIN_U8;
 
@@ -558,11 +569,8 @@ inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
 		
 		// Note: we may not want to extract from the final row
 		EEU8_TCScore lr = ((EEU8_TCScore*)(pvHLoad))[lastWordIdx];
-		TAlScore sc = (TAlScore)(lr - 0xff);
-		if(lr > lrmax) {
-			lrmax = lr;
-		}
-		if(sc >= minsc) {
+		lrmax = std::max(lr,lrmax);
+		if (lr >= minlr) {
 			// Yes, this is legit
 			btncand[btnfilled].init(nrow-1, i, lr);
 			btnfilled++;

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -18,7 +18,7 @@
 typedef SSERegI TMatBuf;
 #else
 // TODO, make it more dynameic
-#define VECT_SIZE 64
+#define VECT_SIZE 16
 typedef uint8_t TMatBuf __attribute__((ext_vector_type(VECT_SIZE)));
 #endif
 
@@ -244,7 +244,7 @@ int filter(int nels,
 #ifdef CPUVECT
 // The input buffers are meant for scalar execution
 // If we have vectors, we must transpose some buffers accordingly
-// Remonder: We groupped same rfdp[ together, so use that info
+// Remonder: We groupped same rfd together, so use that info
 //
 // rf
 //  Org:
@@ -265,6 +265,7 @@ void vect_transpose_rf(const int nels,
 		char       rf_out[]
 		) {
     // Note: We are assuming rounded nels
+#pragma omp parallel for collapse(2)
     for (int b=0; b<(nels/VECT_SIZE); b++) {
        for (size_t r=0; r<rfd; r++) {
 	  for (int v=0; v<VECT_SIZE; v++) {
@@ -273,6 +274,50 @@ void vect_transpose_rf(const int nels,
 	     rf_out[dest_i] = rf_in[source_i];
 	  }
        }
+    }
+}
+
+// The input buffers are meant for scalar execution
+// If we have vectors, we must transpose some buffers accordingly
+// Remonder: We groupped same iter together, so use that info
+//
+// rf
+//  Org: (vs0,vs1) always together, iter consecutive, x5 
+//   el=0 0 1 ...itr5a..MAX_PB_EL-1
+//   el=1                       MAX_PB_EL.+1..+itr5b..2*MAX_PB_EL-1
+//   ...
+//   el=N                                                            N*MAX_PB_EL.+1..+itr5n..(N-1)*MAX_PB_EL-1
+//  New: (vs0x5) (vs1x5), repeated iter times
+//   el=0   0      V           ...   V*(itr5-1)
+//   el=1    1      V+1          ...         V*(itr5-1)+1
+//   ...
+//   el=V-1     V-1     2*V-1            ...              V*itr5-1
+//   el=V                                                         V*itr5 ...
+//
+void vect_transpose_profbuf(const int nels,
+		const size_t  iter,
+		const uint8_t profbuf_in[],
+		uint8_t       profbuf_out[]
+		) {
+    // Note: We are assuming rounded nels
+#pragma omp parallel for collapse(3)
+    for (int b=0; b<(nels/VECT_SIZE); b++) {
+      for (size_t j=0; j<iter; j++) {
+        for (size_t r=0; r<5; r++) {
+	  for (int v=0; v<VECT_SIZE; v++) {
+	     // [MAX_PB_EL,5,iter,2],
+             // ((b,v),r,j,0)
+             uint64_t source_vs0 = (b*VECT_SIZE+v)*uint64_t(MAX_PB_EL)+((r*iter+j)*2);
+             uint64_t source_vs1 = source_vs0+1;
+	     // [BLK,iter,2,5,v]
+	     // (b,j,0,r,v)
+             uint64_t dest_vs0 = ((b*uint64_t(iter)+j)*2*5+r)*uint64_t(VECT_SIZE)+v;
+             uint64_t dest_vs1 = dest_vs0+VECT_SIZE*5;
+	     profbuf_out[dest_vs0] = profbuf_in[source_vs0];
+	     profbuf_out[dest_vs1] = profbuf_in[source_vs1];
+	  }
+	}
+      }
     }
 }
 
@@ -462,8 +507,7 @@ void align_ee8(const int npar, const int nels,
       for (int i=p*elp_pp; (i+VECT_SIZE)<=iend; i+=VECT_SIZE) {
          nerrs+= align_ee8_vect<VECT_SIZE>(i,
 		nrow, iter, colstride, lastWordIdx,minsc, rfd, gaps,
-                profbuf+i*size_t(MAX_PB_EL),
-		rf+i*size_t(rfd), // transposed, now different spacing
+                profbuf+i*size_t(iter*10), rf+i*size_t(rfd), // transposed, now different spacing
 		my_mat,my_btncand,
 		computed_lrmax+i,ref_lrmax+i,ref_btnfilled+i);
       }
@@ -523,9 +567,12 @@ int load_and_align_ee8(const int npar, int nels) {
    }
    // create support buffers
    char    *rf_alt = new  (std::align_val_t(1024)) char[size_t(rfd[0])*nels];
+   uint8_t *profbuf_alt = new (std::align_val_t(1024)) uint8_t[size_t(iter[0])*10*nels];
    // need transposed values for vector operation
    vect_transpose_rf(nels,rfd[0],rf,rf_alt); // rfd homogeneous
+   vect_transpose_profbuf(nels,iter[0],profbuf,profbuf_alt); // iter homogeneous
    std::swap(rf,rf_alt); // use the transposed version from now on... keeping the old just for debugging
+   std::swap(profbuf,profbuf_alt); // use the transposed version from now on... keeping the old just for debugging
 #endif
    auto t2a = std::chrono::high_resolution_clock::now();
    for (int i=0; i<nels; i++) computed_lrmax[i] = -1; // invalidate
@@ -593,6 +640,7 @@ int load_and_align_ee8(const int npar, int nels) {
    fprintf(stderr, "load %.4f s cold align %.4f s hot align %.4f s\n", time_span1.count(), time_span2.count(), time_span3.count());
 
 #ifdef CPUVECT
+   delete[] profbuf_alt;
    delete[] rf_alt;
 #endif
    delete[] btncand;

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -234,7 +234,7 @@ int filter(int nels,
       i++;
    }
 
-   fprintf(stderr, "INFO: Filtered from %i down to %i (%3.2f%%%)\n",int(nels), int(good_els),100.0*good_els/nels);
+   fprintf(stderr, "INFO: Filtered from %i down to %i (%3.2f%%)\n",int(nels), int(good_els),100.0*good_els/nels);
    fprintf(stderr, "INFO: Filter iter: %i rfd: %i gaps: %i nrow: %i colstride: %i lastWordIdx: %i minsc: %i\n",
 		   filter_iter_n,filter_rfd_n,filter_gaps_n,filter_nrow_n,filter_colstride_n,filter_lastWordIdx_n,filter_minsc_n);
    return good_els;
@@ -248,9 +248,9 @@ int align_ee8_one(const int el, // for debuggging purpose
 		const size_t lastWordIdx,
 		const int32_t minsc,
 		const size_t rfd,
+		const uint8_t gaps[4],
                 const SSERegI *profbuf,
 		const char    *rf,
-		const uint8_t gaps[],
                 TMatBuf       *mat,
 		DpBtCandidate *btncand,
                 int32_t       &computed_lrmax, // out
@@ -317,9 +317,9 @@ int align_ee8_vect(const int el, // first, for debuggging purpose
 		const size_t lastWordIdx,
 		const int32_t minsc,
 		const size_t rfd,
+		const uint8_t gaps[4],
                 const SSERegI *profbuf,
 		const char    *rf,
-		const uint8_t gaps[],
                 TMatBuf       *mat,
 		DpBtCandidate *btncand,
                 int32_t       *computed_lrmax, // out
@@ -365,15 +365,15 @@ int align_ee8_vect(const int el, // first, for debuggging purpose
 #endif
 
 void align_ee8(const int npar, const int nels,
-		const size_t nrow[],
-		const size_t iter[],
-		const size_t colstride[],
-		const size_t lastWordIdx[],
-		const int32_t minsc[],
-		const size_t rfd[],
+		const size_t nrow,
+		const size_t iter,
+		const size_t colstride,
+		const size_t lastWordIdx,
+		const int32_t minsc,
+		const size_t  rfd,
+		const uint8_t gaps[4],
                 const SSERegI profbuf[],
 		const char    rf[],
-		const uint8_t gaps[],
                 TMatBuf       mat[], 
 		DpBtCandidate btncand[],
                 int32_t       computed_lrmax[], // out
@@ -409,8 +409,8 @@ void align_ee8(const int npar, const int nels,
 	DpBtCandidate *my_btncand = btncand+i*size_t(MAX_RF_EL);
 #endif
          nerrs+= align_ee8_one(i,
-		nrow[i], iter[i], colstride[i], lastWordIdx[i],minsc[i], rfd[i],
-                profbuf+i*size_t(MAX_PB_EL),rf+i*size_t(MAX_RF_EL),gaps+4*i,
+		nrow, iter, colstride, lastWordIdx,minsc, rfd, gaps,
+                profbuf+i*size_t(MAX_PB_EL),rf+i*size_t(MAX_RF_EL),
 		my_mat,my_btncand,
 		computed_lrmax[i],ref_lrmax[i],ref_btnfilled[i]);
       }
@@ -419,8 +419,8 @@ void align_ee8(const int npar, const int nels,
       // HACK, TODO: Deal with rounding
       for (int i=p*elp_pp; (i+VECT_SIZE)<=iend; i+=VECT_SIZE) {
          nerrs+= align_ee8_vect<VECT_SIZE>(i,
-		nrow[i], iter[i], colstride[i], lastWordIdx[i],minsc[i], rfd[i],
-                profbuf+i*size_t(MAX_PB_EL),rf+i*size_t(MAX_RF_EL),gaps+4*i,
+		nrow, iter, colstride, lastWordIdx,minsc, rfd, gaps,
+                profbuf+i*size_t(MAX_PB_EL),rf+i*size_t(MAX_RF_EL),
 		my_mat,my_btncand,
 		computed_lrmax+i,ref_lrmax+i,ref_btnfilled+i);
       }
@@ -477,9 +477,12 @@ int load_and_align_ee8(const int npar, int nels) {
    auto t2a = std::chrono::high_resolution_clock::now();
    for (int i=0; i<nels; i++) computed_lrmax[i] = -1; // invalidate
    auto t2b = std::chrono::high_resolution_clock::now();
+   // we filtered the eleemnts, we can now assume they are homogeneous
    align_ee8(npar, nels,
-		nrow, iter, colstride, lastWordIdx,minsc,rfd,
-		profbuf,rf,gaps,mat,btncand,
+		nrow[0], iter[0], colstride[0], lastWordIdx[0],minsc[0],rfd[0], // homogeneous
+		gaps, // 4 elements, so passing by pointer, but still homogeneous
+		profbuf,rf,
+		mat,btncand,
 		computed_lrmax,ref_lrmax,ref_btnfilled);
    auto t3a = std::chrono::high_resolution_clock::now();
    {
@@ -501,9 +504,11 @@ int load_and_align_ee8(const int npar, int nels) {
    for (int i=0; i<nels; i++) computed_lrmax[i] = -1; // invalidate
    auto t3b = std::chrono::high_resolution_clock::now();
    align_ee8(npar, nels,
-		nrow, iter, colstride, lastWordIdx,minsc,rfd,
-		profbuf,rf,gaps,mat,btncand,
-		computed_lrmax, ref_lrmax, ref_btnfilled);
+		nrow[0], iter[0], colstride[0], lastWordIdx[0],minsc[0],rfd[0], // homogeneous
+		gaps, // 4 elements, so passing by pointer, but still homogeneous
+		profbuf,rf,
+		mat,btncand,
+		computed_lrmax,ref_lrmax,ref_btnfilled);
    auto t4 = std::chrono::high_resolution_clock::now();
    {
      int nerrs = 0;

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -336,7 +336,18 @@ int main(int argv, const char* argc[]) {
      uint8_t a = 20;
      uint8_t b = 40;
      if (__builtin_elementwise_sub_sat(a,b)!=0) {
-        fprintf(stderr, "ERROR: Broken compiler detected!\n");
+        fprintf(stderr, "ERROR: Broken compiler detected, builtin scalar sub_sat produces wrong result!\n");
+	return 2;
+     }
+   }
+   {
+     // make sure this compiler is not broken
+     typedef uint8_t uint8x16_t __attribute__((ext_vector_type(16)));
+     uint8x16_t a = 20;
+     uint8x16_t b = 40;
+     uint8x16_t r = 0;
+     if (__builtin_reduce_or(__builtin_elementwise_sub_sat(a,b)!=r)) { // enough is one is not equal
+        fprintf(stderr, "ERROR: Broken compiler detected, builtin vector sub_sat produces wrong result!\n");
 	return 2;
      }
    }

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -241,6 +241,43 @@ int filter(int nels,
    return good_els;
 }
 
+#ifdef CPUVECT
+// The input buffers are meant for scalar execution
+// If we have vectors, we must transpose some buffers accordingly
+// Remonder: We groupped same rfdp[ together, so use that info
+//
+// rf
+//  Org:
+//   el=0 0...rfd0..MAX_RF_EL-1
+//   el=1                       MAX_RF_EL..+rfd1..2*MAX_RF_EL-1
+//   ...
+//   el=N                                                            N*MAX_RF_EL..+rfdN..(N-1)*MAX_RF_EL-1
+//  New:
+//   el=0   0      V           ...   V*(rfd-1)
+//   el=1    1      V+1          ...         V*(rfd-1)+1
+//   ...
+//   el=V-1     V-1     2*V-1            ...              V*rfd-1
+//   el=V                                                         V*rfd ...
+//
+void vect_transpose_rf(const int nels,
+		const size_t  rfd,
+		const char rf_in[],
+		char       rf_out[]
+		) {
+    // Note: We are assuming rounded nels
+    for (int b=0; b<(nels/VECT_SIZE); b++) {
+       for (size_t r=0; r<rfd; r++) {
+	  for (int v=0; v<VECT_SIZE; v++) {
+             uint64_t source_i = (b*VECT_SIZE+v)*uint64_t(MAX_RF_EL)+r;
+             uint64_t dest_i = (b*uint64_t(rfd)+r)*uint64_t(VECT_SIZE)+v;
+	     rf_out[dest_i] = rf_in[source_i];
+	  }
+       }
+    }
+}
+
+#endif
+
 #ifndef CPUVECT
 int align_ee8_one(const int el, // for debuggging purpose
 		const size_t nrow,
@@ -380,7 +417,11 @@ void align_ee8(const int npar, const int nels,
                 int32_t       computed_lrmax[], // out
                 const int32_t ref_lrmax[],
                 const int32_t ref_btnfilled[]) {
-   const int elp_pp = (nels+ (npar-1))/npar; // round up
+   int elp_pp = (nels+ (npar-1))/npar; // round up
+#ifdef CPUVECT
+   // keep block multiple of VECT_SIZE
+   elp_pp = ((elp_pp + (VECT_SIZE-1))/VECT_SIZE)*VECT_SIZE; // round up
+#endif 
    int nerrs = 0;
 #ifdef OMPGPU
 #pragma omp target teams distribute reduction(+:nerrs)
@@ -417,11 +458,12 @@ void align_ee8(const int npar, const int nels,
       }
 
 #else /* CPUVECT */
-      // HACK, TODO: Deal with rounding
+      // Note: Assuming nels was rounded
       for (int i=p*elp_pp; (i+VECT_SIZE)<=iend; i+=VECT_SIZE) {
          nerrs+= align_ee8_vect<VECT_SIZE>(i,
 		nrow, iter, colstride, lastWordIdx,minsc, rfd, gaps,
-                profbuf+i*size_t(MAX_PB_EL),rf+i*size_t(MAX_RF_EL),
+                profbuf+i*size_t(MAX_PB_EL),
+		rf+i*size_t(rfd), // transposed, now different spacing
 		my_mat,my_btncand,
 		computed_lrmax+i,ref_lrmax+i,ref_btnfilled+i);
       }
@@ -441,7 +483,6 @@ int load_and_align_ee8(const int npar, int nels) {
    int32_t *ref_lrmax = new int32_t[nels];
    int32_t *ref_btnfilled = new int32_t[nels];
    SSERegI *profbuf = new (std::align_val_t(1024))  SSERegI[size_t(nels)*MAX_PB_EL];
-   //fprintf(stderr,"Allocated %li profbuf: %p\n",long(size_t(nels)*MAX_PB_EL),profbuf);
 #if defined(PRE_LR_SCALAR)
    // no mat or btncand, just pass NULLs around 
    TMatBuf        *mat = nullptr;
@@ -456,7 +497,6 @@ int load_and_align_ee8(const int npar, int nels) {
    DpBtCandidate *btncand = new  (std::align_val_t(1024)) DpBtCandidate[size_t(MAX_RF_EL)*nels];
 #endif
    char    *rf = new  (std::align_val_t(1024)) char[size_t(MAX_RF_EL)*nels];
-   //fprintf(stderr,"Allocated %li rf: %p\n",long(size_t(MAX_RF_EL)*nels),rf);
    size_t  *nrow = new size_t[nels];
    size_t  *iter = new size_t[nels];
    size_t  *colstride = new size_t[nels];
@@ -475,6 +515,18 @@ int load_and_align_ee8(const int npar, int nels) {
    nels = filter(nels,
                 nrow, iter, colstride, lastWordIdx, minsc,
                 rfd, profbuf, rf, gaps, ref_lrmax, ref_btnfilled);
+#ifdef CPUVECT
+   // TODO: Fix the code to support non-multiple numbers
+   if ((nels%VECT_SIZE)!=0) {
+      nels = (nels/VECT_SIZE)*VECT_SIZE; // round down
+      fprintf(stderr, "INFO: Rounded down to %i\n",int(nels));
+   }
+   // create support buffers
+   char    *rf_alt = new  (std::align_val_t(1024)) char[size_t(rfd[0])*nels];
+   // need transposed values for vector operation
+   vect_transpose_rf(nels,rfd[0],rf,rf_alt); // rfd homogeneous
+   std::swap(rf,rf_alt); // use the transposed version from now on... keeping the old just for debugging
+#endif
    auto t2a = std::chrono::high_resolution_clock::now();
    for (int i=0; i<nels; i++) computed_lrmax[i] = -1; // invalidate
    auto t2b = std::chrono::high_resolution_clock::now();
@@ -540,6 +592,9 @@ int load_and_align_ee8(const int npar, int nels) {
    auto time_span3 = std::chrono::duration_cast<std::chrono::duration<double>>(t4 - t3b);
    fprintf(stderr, "load %.4f s cold align %.4f s hot align %.4f s\n", time_span1.count(), time_span2.count(), time_span3.count());
 
+#ifdef CPUVECT
+   delete[] rf_alt;
+#endif
    delete[] btncand;
    delete[] gaps;
    delete[] rfd;

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -14,6 +14,14 @@
 
 #define SKIPPED_LRMAX -2000
 
+#ifndef CPUVECT
+typedef SSERegI TMatBuf;
+#else
+// TODO, make it more dynameic
+#define VECT_SIZE 16
+typedef uint8_t TMatBuf __attribute__((ext_vector_type(VECT_SIZE)));
+#endif
+
 int load_data(int nels,
 		size_t nrow[],
 		size_t iter[],
@@ -88,6 +96,7 @@ int load_results(int nels,
    return 0;
 }
 
+#ifndef CPUVECT
 int align_ee8_one(const int el, // for debuggging purpose
 		const size_t nrow,
 		const size_t iter,
@@ -98,7 +107,7 @@ int align_ee8_one(const int el, // for debuggging purpose
                 const SSERegI *profbuf,
 		const char    *rf,
 		const uint8_t gaps[],
-                SSERegI       *mat,
+                TMatBuf       *mat,
 		DpBtCandidate *btncand,
                 int32_t       &computed_lrmax, // out
                 const int32_t ref_lrmax,
@@ -150,6 +159,61 @@ int align_ee8_one(const int el, // for debuggging purpose
 	return nerrs;
 }
 
+#else
+template<int VLen>
+int align_ee8_vect(const int el, // first, for debuggging purpose
+		const size_t nrow,
+		const size_t iter,
+		const size_t colstride,
+		const size_t lastWordIdx,
+		const int32_t minsc,
+		const size_t rfd,
+                const SSERegI *profbuf,
+		const char    *rf,
+		const uint8_t gaps[],
+                TMatBuf       *mat,
+		DpBtCandidate *btncand,
+                int32_t       *computed_lrmax, // out
+                const int32_t *ref_lrmax,
+                const int32_t *ref_btnfilled) {
+	typedef uint8_t vectu8_t __attribute__((ext_vector_type(VLen)));
+	uint16_t btnfilled[VLen];
+        //fprintf(stderr,"Using profbuf %p\n",profbuf);
+        //fprintf(stderr,"Using rf %p\n",rf);
+	const vectu8_t lrmax = EEU8_alignNucleotidesVect<VLen,uint16_t>(
+					(const vectu8_t*) profbuf, (const vectu8_t*) rf, rfd,
+					mat,
+                                        iter, colstride, lastWordIdx,
+					minsc, nrow,
+					btncand, btnfilled,
+					gaps[0],gaps[1],gaps[2],gaps[3]);
+	int nerrs = 0;
+	for(int i=0; i<VLen; i++) computed_lrmax[i] = lrmax[i];
+	for(int i=0; i<VLen; i++) if (int(ref_lrmax[i]) != int(lrmax[i])) nerrs++;
+#ifndef PRE_LR_SCALAR
+	for(int i=0; i<VLen; i++) if (int(ref_btnfilled[i]) != int(btnfilled[i])) nerrs++;
+#else
+	//TAlScore sc = (TAlScore)(lrmax - 0xff);
+	//if ((ref_btnfilled!=0) != (sc>=minsc)) nerrs++;
+#endif
+
+#if 0
+
+#ifndef NO_CHECK_PRINT
+	if (int(ref_lrmax) != int(lrmax)) fprintf(stderr, "[%i] MISMATCH in lrmax (%i != %i)\n",el,int(lrmax), int(ref_lrmax));
+#ifndef PRE_LR_SCALAR
+	if (int(ref_btnfilled) != int(btnfilled)) fprintf(stderr, "[%i] MISMATCH in ref_btnfilled (%i != %i)\n",el,int(btnfilled), int(ref_btnfilled));
+#else
+	if ((ref_btnfilled!=0) != (sc>=minsc)) fprintf(stderr, "[%i] MISMATCH in ref_btnfilled (%i) vs sc %i minsc %i)\n",el,int(ref_btnfilled), int(sc), int(minsc));
+#endif
+#endif
+#endif
+	// TODO: In case of PRE_LR_SCALAR, we should also likely want to test the complete align on the elements that need it
+	//       But that's probably better done in a separate test
+	return nerrs;
+}
+
+#endif
 
 void align_ee8(const int npar, const int nels,
 		const size_t nrow[],
@@ -161,7 +225,7 @@ void align_ee8(const int npar, const int nels,
                 const SSERegI profbuf[],
 		const char    rf[],
 		const uint8_t gaps[],
-                SSERegI       mat[], 
+                TMatBuf       mat[], 
 		DpBtCandidate btncand[],
                 int32_t       computed_lrmax[], // out
                 const int32_t ref_lrmax[],
@@ -177,20 +241,22 @@ void align_ee8(const int npar, const int nels,
       const int iend = std::min((p+1)*elp_pp,nels);
 #if defined(PRE_LR_SCALAR)
 	// no mat or btncand, just pass NULLs around 
-	SSERegI       *my_mat = nullptr;
+	TMatBuf       *my_mat = nullptr;
 	DpBtCandidate *my_btncand = nullptr;
 #elif !defined(OMPGPU)
 	// the following loop is sequential, so can reuse the buffer
-	SSERegI       *my_mat = mat+p*size_t(MAX_MAT_EL);
+	TMatBuf       *my_mat = mat+p*size_t(MAX_MAT_EL);
 	DpBtCandidate *my_btncand = btncand+p*size_t(MAX_RF_EL);
 #endif
+#ifndef CPUVECT
+
 #ifdef OMPGPU
 #pragma omp parallel for reduction(+:nerrs)
 #endif
       for (int i=p*elp_pp; i<iend; i++) {
 #if defined(OMPGPU) && !defined(PRE_LR_SCALAR)
 	// the loop is parallel, so we must use a different buffer for each element
-	SSERegI       *my_mat = mat+i*size_t(MAX_MAT_EL);
+	TMatBuf       *my_mat = mat+i*size_t(MAX_MAT_EL);
 	DpBtCandidate *my_btncand = btncand+i*size_t(MAX_RF_EL);
 #endif
          nerrs+= align_ee8_one(i,
@@ -199,6 +265,17 @@ void align_ee8(const int npar, const int nels,
 		my_mat,my_btncand,
 		computed_lrmax[i],ref_lrmax[i],ref_btnfilled[i]);
       }
+
+#else /* CPUVECT */
+      // HACK, TODO: Deal with rounding
+      for (int i=p*elp_pp; (i+VECT_SIZE)<=iend; i+=VECT_SIZE) {
+         nerrs+= align_ee8_vect<VECT_SIZE>(i,
+		nrow[i], iter[i], colstride[i], lastWordIdx[i],minsc[i], rfd[i],
+                profbuf+i*size_t(MAX_PB_EL),rf+i*size_t(MAX_RF_EL),gaps+4*i,
+		my_mat,my_btncand,
+		computed_lrmax+i,ref_lrmax+i,ref_btnfilled+i);
+      }
+#endif
    }
 
    if (nerrs!=0) {
@@ -214,20 +291,22 @@ int load_and_align_ee8(const int npar, const int nels) {
    int32_t *ref_lrmax = new int32_t[nels];
    int32_t *ref_btnfilled = new int32_t[nels];
    SSERegI *profbuf = new SSERegI[size_t(nels)*MAX_PB_EL];
+   //fprintf(stderr,"Allocated %li profbuf: %p\n",long(size_t(nels)*MAX_PB_EL),profbuf);
 #if defined(PRE_LR_SCALAR)
    // no mat or btncand, just pass NULLs around 
-   SSERegI        *mat = nullptr;
+   TMatBuf        *mat = nullptr;
    DpBtCandidate *btncand = nullptr;
 #elif !defined(OMPGPU)
    // one per thread is enough on the CPU
-   SSERegI       *mat = new SSERegI[size_t(npar)*MAX_MAT_EL];
+   TMatBuf       *mat = new TMatBuf[size_t(npar)*MAX_MAT_EL];
    DpBtCandidate *btncand = new DpBtCandidate[size_t(MAX_RF_EL)*npar];
 #else
    // no shortcuts on the GPU
-   SSERegI       *mat = new SSERegI[size_t(nels)*MAX_MAT_EL];
+   TMatBuf       *mat = new TMatBuf[size_t(nels)*MAX_MAT_EL];
    DpBtCandidate *btncand = new DpBtCandidate[size_t(MAX_RF_EL)*nels];
 #endif
    char    *rf = new char[size_t(MAX_RF_EL)*nels];
+   //fprintf(stderr,"Allocated %li rf: %p\n",long(size_t(MAX_RF_EL)*nels),rf);
    size_t  *nrow = new size_t[nels];
    size_t  *iter = new size_t[nels];
    size_t  *colstride = new size_t[nels];

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -330,5 +330,16 @@ int main(int argv, const char* argc[]) {
    int npar = atoi(argc[1]);
    int nels = atoi(argc[2]);
 
+#ifndef BUILTIN_SUB_SAT_BROKEN
+   {
+     // make sure this compiler is not broken
+     uint8_t a = 20;
+     uint8_t b = 40;
+     if (__builtin_elementwise_sub_sat(a,b)!=0) {
+        fprintf(stderr, "ERROR: Broken compiler detected!\n");
+	return 2;
+     }
+   }
+#endif
    return load_and_align_ee8(npar,nels);
 }

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -18,7 +18,7 @@
 typedef SSERegI TMatBuf;
 #else
 // TODO, make it more dynameic
-#define VECT_SIZE 16
+#define VECT_SIZE 64
 typedef uint8_t TMatBuf __attribute__((ext_vector_type(VECT_SIZE)));
 #endif
 
@@ -96,6 +96,7 @@ int load_results(int nels,
    return 0;
 }
 
+// Swap all data for two elements
 void swap_data(size_t my, size_t other,
                 size_t nrow[],
                 size_t iter[],
@@ -439,7 +440,7 @@ int load_and_align_ee8(const int npar, int nels) {
    int32_t *computed_lrmax = new int32_t[nels];
    int32_t *ref_lrmax = new int32_t[nels];
    int32_t *ref_btnfilled = new int32_t[nels];
-   SSERegI *profbuf = new SSERegI[size_t(nels)*MAX_PB_EL];
+   SSERegI *profbuf = new (std::align_val_t(1024))  SSERegI[size_t(nels)*MAX_PB_EL];
    //fprintf(stderr,"Allocated %li profbuf: %p\n",long(size_t(nels)*MAX_PB_EL),profbuf);
 #if defined(PRE_LR_SCALAR)
    // no mat or btncand, just pass NULLs around 
@@ -447,14 +448,14 @@ int load_and_align_ee8(const int npar, int nels) {
    DpBtCandidate *btncand = nullptr;
 #elif !defined(OMPGPU)
    // one per thread is enough on the CPU
-   TMatBuf       *mat = new TMatBuf[size_t(npar)*MAX_MAT_EL];
-   DpBtCandidate *btncand = new DpBtCandidate[size_t(MAX_RF_EL)*npar];
+   TMatBuf       *mat = new  (std::align_val_t(1024))  TMatBuf[size_t(npar)*MAX_MAT_EL];
+   DpBtCandidate *btncand = new  (std::align_val_t(1024)) DpBtCandidate[size_t(MAX_RF_EL)*npar];
 #else
    // no shortcuts on the GPU
-   TMatBuf       *mat = new TMatBuf[size_t(nels)*MAX_MAT_EL];
-   DpBtCandidate *btncand = new DpBtCandidate[size_t(MAX_RF_EL)*nels];
+   TMatBuf       *mat = new  (std::align_val_t(1024)) TMatBuf[size_t(nels)*MAX_MAT_EL];
+   DpBtCandidate *btncand = new  (std::align_val_t(1024)) DpBtCandidate[size_t(MAX_RF_EL)*nels];
 #endif
-   char    *rf = new char[size_t(MAX_RF_EL)*nels];
+   char    *rf = new  (std::align_val_t(1024)) char[size_t(MAX_RF_EL)*nels];
    //fprintf(stderr,"Allocated %li rf: %p\n",long(size_t(MAX_RF_EL)*nels),rf);
    size_t  *nrow = new size_t[nels];
    size_t  *iter = new size_t[nels];

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -96,6 +96,150 @@ int load_results(int nels,
    return 0;
 }
 
+void swap_data(size_t my, size_t other,
+                size_t nrow[],
+                size_t iter[],
+                size_t colstride[],
+                size_t lastWordIdx[],
+                int32_t minsc[],
+                size_t rfd[],
+                SSERegI profbuf[],
+                char    rf[],
+                uint8_t gaps[],
+                int32_t lrmax[],
+                int32_t btnfilled[]
+                ) {
+	if (my==other) return; // nothing to do
+	std::swap(nrow[my],nrow[other]);
+	std::swap(iter[my],iter[other]);
+	std::swap(colstride[my],colstride[other]);
+	std::swap(lastWordIdx[my],lastWordIdx[other]);
+	std::swap(minsc[my],minsc[other]);
+	std::swap(rfd[my],rfd[other]);
+	for (size_t i=0; i<MAX_PB_EL; i++) std::swap(profbuf[my*size_t(MAX_PB_EL)+i],profbuf[other*size_t(MAX_PB_EL)+i]);
+	for (size_t i=0; i<MAX_RF_EL; i++) std::swap(rf[my*size_t(MAX_RF_EL)+i],rf[other*size_t(MAX_RF_EL)+i]);
+	for (size_t i=0; i<4; i++) std::swap(gaps[my*4+i],gaps[other*4+i]);
+	std::swap(lrmax[my],lrmax[other]);
+	std::swap(btnfilled[my],btnfilled[other]);
+}
+
+// The accelerated algoritms need homogeneous alignment sizes
+// Move anything that does not fit to the end
+// Return how many homogeneous elements we have
+int filter(int nels,
+		size_t nrow[],
+		size_t iter[],
+		size_t colstride[],
+		size_t lastWordIdx[],
+		int32_t minsc[],
+		size_t rfd[],
+                SSERegI profbuf[],
+		char    rf[],
+		uint8_t gaps[],
+		int32_t lrmax[],
+		int32_t btnfilled[]
+		) {
+   uint32_t *gaps4 = (uint32_t*)gaps;
+   bool is_first = true;
+   size_t nrow_first;
+   size_t colstride_first;
+   size_t lastWordIdx_first;
+   int32_t minsc_first;
+   size_t rfd_first;
+   uint32_t gaps_first;
+
+   int filter_iter_n = 0;
+   int filter_nrow_n = 0;
+   int filter_colstride_n = 0;
+   int filter_lastWordIdx_n = 0;
+   int filter_minsc_n = 0;
+   int filter_rfd_n = 0;
+   int filter_gaps_n = 0;
+   int good_els = nels;
+   int i = 0;
+   while (i<good_els) {
+      if (iter[i]!=((151+(NBYTES_PER_REG-1))/NBYTES_PER_REG)) {
+	// keep the most relevant one
+	swap_data(i, good_els-1,
+                nrow, iter, colstride, lastWordIdx, minsc,
+                rfd, profbuf, rf, gaps, lrmax, btnfilled);
+	good_els--;
+	filter_iter_n++;
+	continue;
+      }
+      // for all other values, we will default to the first we see
+      if (is_first) {
+	nrow_first = nrow[i];
+	colstride_first = colstride[i];
+	lastWordIdx_first = lastWordIdx[i];
+ 	minsc_first = minsc[i];
+ 	rfd_first = rfd[i];
+   	gaps_first = gaps4[i];
+	is_first = false;
+      }
+      if (rfd[i]!=rfd_first) {
+	// keep the most relevant one
+	swap_data(i, good_els-1,
+                nrow, iter, colstride, lastWordIdx, minsc,
+                rfd, profbuf, rf, gaps, lrmax, btnfilled);
+	good_els--;
+	filter_rfd_n++;
+	continue;
+      }
+      if (gaps4[i]!=gaps_first) {
+	// keep the most relevant one
+	swap_data(i, good_els-1,
+                nrow, iter, colstride, lastWordIdx, minsc,
+                rfd, profbuf, rf, gaps, lrmax, btnfilled);
+	good_els--;
+	filter_gaps_n++;
+	continue;
+      }
+      if (nrow[i]!=nrow_first) {
+	// keep the most relevant one
+	swap_data(i, good_els-1,
+                nrow, iter, colstride, lastWordIdx, minsc,
+                rfd, profbuf, rf, gaps, lrmax, btnfilled);
+	good_els--;
+	filter_nrow_n++;
+	continue;
+      }
+      if (colstride[i]!=colstride_first) {
+	// keep the most relevant one
+	swap_data(i, good_els-1,
+                nrow, iter, colstride, lastWordIdx, minsc,
+                rfd, profbuf, rf, gaps, lrmax, btnfilled);
+	good_els--;
+	filter_colstride_n++;
+	continue;
+      }
+      if (lastWordIdx[i]!=lastWordIdx_first) {
+	// keep the most relevant one
+	swap_data(i, good_els-1,
+                nrow, iter, colstride, lastWordIdx, minsc,
+                rfd, profbuf, rf, gaps, lrmax, btnfilled);
+	good_els--;
+	filter_lastWordIdx_n++;
+	continue;
+      }
+      if (minsc[i]!=minsc_first) {
+	// keep the most relevant one
+	swap_data(i, good_els-1,
+                nrow, iter, colstride, lastWordIdx, minsc,
+                rfd, profbuf, rf, gaps, lrmax, btnfilled);
+	good_els--;
+	filter_minsc_n++;
+	continue;
+      }
+      i++;
+   }
+
+   fprintf(stderr, "INFO: Filtered from %i down to %i (%3.2f%%%)\n",int(nels), int(good_els),100.0*good_els/nels);
+   fprintf(stderr, "INFO: Filter iter: %i rfd: %i gaps: %i nrow: %i colstride: %i lastWordIdx: %i minsc: %i\n",
+		   filter_iter_n,filter_rfd_n,filter_gaps_n,filter_nrow_n,filter_colstride_n,filter_lastWordIdx_n,filter_minsc_n);
+   return good_els;
+}
+
 #ifndef CPUVECT
 int align_ee8_one(const int el, // for debuggging purpose
 		const size_t nrow,
@@ -121,11 +265,16 @@ int align_ee8_one(const int el, // for debuggging purpose
 					btncand, btnfilled,
 					gaps[0],gaps[1],gaps[2],gaps[3]);
 #else
+
+#if 0
+	// The upstream filter takes care of this...
 	// Note: The vast majority of reads have iter==151
 	if (iter!=151) {
 		computed_lrmax = SKIPPED_LRMAX; // special value to signal we did not actually compute it
 		return 0;  // TODO: We may properly use the right template function, or call slow align directly
 	}
+#endif
+
 #ifndef PBMASK
 	const EEU8_TCScore lrmax = EEU8_alignNucleotidesLRScalar<uint16_t,151>(profbuf, rf, rfd,
 					nrow,
@@ -286,7 +435,7 @@ void align_ee8(const int npar, const int nels,
 
 }
 
-int load_and_align_ee8(const int npar, const int nels) {
+int load_and_align_ee8(const int npar, int nels) {
    int32_t *computed_lrmax = new int32_t[nels];
    int32_t *ref_lrmax = new int32_t[nels];
    int32_t *ref_btnfilled = new int32_t[nels];
@@ -322,6 +471,9 @@ int load_and_align_ee8(const int npar, const int nels) {
 		profbuf,rf,gaps) !=0 ) return 1;
    if (load_results(nels,
 		ref_lrmax, ref_btnfilled) !=0 ) return 1;
+   nels = filter(nels,
+                nrow, iter, colstride, lastWordIdx, minsc,
+                rfd, profbuf, rf, gaps, ref_lrmax, ref_btnfilled);
    auto t2a = std::chrono::high_resolution_clock::now();
    for (int i=0; i<nels; i++) computed_lrmax[i] = -1; // invalidate
    auto t2b = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Allow vector processing of multiple alignments, using the scalar logic for each.
Performance comparable to original parallel-in-element logic.