### PR TITLE
Squashed batchAligns branch:

### DIFF
--- a/aligner_sw.cpp
+++ b/aligner_sw.cpp
@@ -227,6 +227,30 @@ bool SwAligner::initRef(
 		extend);     // true iff this is a seed extension
 }
 
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+void SwAligner::fillCandProfbuf(bool fw, uint8_t* out_profbuf, int8_t out_gaps[4])
+{
+	assert(initedRead());
+	buildQueryProfileEnd2EndSseU8(fw);
+	const auto& d = fw ? sseU8fw_ : sseU8rc_;
+	const size_t nrow = dpRows();
+	const size_t nbytes = ALPHA_SIZE * nrow * 2;
+	memcpy(out_profbuf, reinterpret_cast<const uint8_t*>(d.profbuf_.ptr()), nbytes);
+	out_gaps[0] = (int8_t)sc_->refGapOpen();
+	out_gaps[1] = (int8_t)sc_->refGapExtend();
+	out_gaps[2] = (int8_t)sc_->readGapOpen();
+	out_gaps[3] = (int8_t)sc_->readGapExtend();
+}
+
+void SwAligner::fillCandRf(char* out_rf, uint16_t& out_rflen, uint16_t& out_nrow) const
+{
+	assert(initedRef() && initedRead());
+	memcpy(out_rf, rf_, rflen_);
+	out_rflen = (uint16_t)rflen_;
+	out_nrow  = (uint16_t)dpRows();
+}
+#endif
+
 /**
  * Align read 'rd' to reference using read & reference information given
  * last time init() was called.

--- a/aligner_sw.h
+++ b/aligner_sw.h
@@ -287,6 +287,35 @@ public:
 	 * last time init() was called.  Uses dynamic programming.
 	 */
 	bool align(TAlScore& best);
+	bool filterLRM11(TAlScore minsc);
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+	// Run the LRM11Scalar pre-filter over flat candidate arrays.
+	// flat_passed[i] is set to true if candidate i may align, false if it can be skipped.
+	// Implemented in aligner_swsse_ee_u8.cpp; uses GPU offload when OMPGPU is defined.
+	static void runLRM11Filter(
+		int             total_cands,
+		int             num_mates,     // actual mate count; gaps/minsc indexed by [mate]
+		const uint8_t*  flat_profbuf,  // [num_mates * 2 * ALPHA_SIZE * ALN_MAX_ROWS * 2] -- fw+rc per mate
+		const char*     flat_rf,       // [total_cands * (ALN_MAX_COLS + 2)]
+		const int8_t*   flat_gaps,     // [num_mates * 4]
+		const uint16_t* flat_rflen,    // [total_cands]
+		const uint16_t* flat_nrow,     // [total_cands]
+		const int32_t*  flat_minsc,    // [num_mates]
+		const uint32_t* flat_mate,     // [total_cands] -- mate*2+(fw?0:1), indexes profbuf directly
+		bool*           flat_passed);  // [total_cands]
+#endif
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+	// Called once per mate per orientation (after initRead). Writes query profile.
+	// out_profbuf: ALPHA_SIZE * dpRows() * 2 bytes; fw selects forward or RC profile.
+	// out_gaps: {refGapOpen, refGapExtend, readGapOpen, readGapExtend} (orientation-independent).
+	void fillCandProfbuf(bool fw, uint8_t* out_profbuf, int8_t out_gaps[4]);
+	// Called once per candidate (after initRef). Writes reference window and dimensions.
+	// Must be called after initRef(BitPairReference,...).
+	// out_rf:    rflen_ bytes (mask-encoded reference chars)
+	// out_rflen: set to rflen_
+	// out_nrow:  set to dpRows()
+	void fillCandRf(char* out_rf, uint16_t& out_rflen, uint16_t& out_nrow) const;
+#endif
 	bool alignEnd2EndSseU8(TAlScore& best);
 #ifdef ENABLE_I16
 	bool alignEnd2EndSseI16(TAlScore& best);

--- a/aligner_sw_driver.cpp
+++ b/aligner_sw_driver.cpp
@@ -471,6 +471,266 @@ int SwDriver::extendSeeds(
 	return EXTEND_EXHAUSTED_CANDIDATES;
 }
 
+/*
+ * BWT walk -> collect DP candidates
+ * Ran before running alignment. This looks through BWT and gets the best matches via BWT
+ * then calls adds them to a list before running alignment
+ */
+int SwDriver::extendSeedsCollect(
+	const Ebwt& ebwtFw,
+	const BitPairReference& ref,
+	SwAligner& swa,
+	const Scoring& sc,
+	const int seedmms,
+	const int seedlen,
+	const int seedival,
+	const TAlScore minsc,
+	const int nceil,
+	const size_t maxhalf,
+	PerReadMetrics& prm,
+	EList<ExtendCandidate>& cands
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+	, uint32_t  mate_idx,
+	size_t    cand_offset,
+	uint8_t*  flat_profbuf,
+	char*     flat_rf,
+	int8_t*   flat_gaps,
+	uint16_t* flat_rflen,
+	uint16_t* flat_nrow,
+	uint32_t* flat_mate
+#endif
+	)
+{
+	cands.clear();
+
+	const size_t rows    = swa.dpRows();
+	const size_t rdlen   = rows;
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+	// Build both fw and rc query profiles once per mate.
+	// flat_profbuf slot [mate*2+0] = fw, [mate*2+1] = rc.
+	// flat_mate[ci] = mate*2 + (fw?0:1) so the kernel picks the right slot.
+	// Gaps are orientation-independent; written once at flat_gaps[mate*4].
+	{
+		const size_t pb_stride = ALPHA_SIZE * ALN_MAX_ROWS * 2;
+		int8_t dummy_gaps[4]; // gaps written by the fw call; same for rc
+		swa.fillCandProfbuf(true,  flat_profbuf + ((size_t)mate_idx * 2 + 0) * pb_stride, flat_gaps + (size_t)mate_idx * 4);
+		swa.fillCandProfbuf(false, flat_profbuf + ((size_t)mate_idx * 2 + 1) * pb_stride, dummy_gaps);
+	}
+#endif
+
+	assert_geq(nceil, 0);
+	assert_leq((size_t)nceil, rdlen);
+
+	TAlScore perfectScore = sc.perfectScore(rdlen);
+	if(minsc == perfectScore) {
+		fprintf(stderr, "Warning, internal logical: Found perfect score in extendSeedsCollect\n");
+		return EXTEND_PERFECT_SCORE;
+	}
+	const int readGaps = sc.maxReadGaps(minsc, rdlen);
+	const int refGaps  = sc.maxRefGaps(minsc, rdlen);
+
+	DynProgFramer dpframe(!reportOverhangs);
+	const uint32_t sp_size = satpos_.size();
+
+	for(uint32_t i = 0; i < sp_size; i++) {
+		auto &gws = gws_[0];
+
+		const SATupleAndPos& satpos = satpos_[i];
+		const size_t sat_size  = satpos.sat.size();
+		const bool fw          = satpos.pos.fw;
+		uint32_t rdoff         = satpos.pos.rdoff;
+		uint32_t seedhitlen    = satpos.pos.seedlen;
+
+		if(!fw) {
+			rdoff = (uint32_t)(rdlen - rdoff - seedhitlen);
+		}
+
+		{
+			SARangeWithOffs<TSlice> sa(
+				satpos.sat.topf, satpos.sat.key.len,
+				satpos.sat.offs, satpos.sat.fmap);
+			gws.reset();
+			gws.init(ebwtFw, ref, sa);
+			assert(gws.initialized());
+		}
+
+		for(uint32_t elt = 0; elt < sat_size; elt++) {
+			assert(!gws.done());
+			prm.nExIters++;
+			WalkResult wr;
+			SARangeWithOffs<TSlice> sa(
+				satpos.sat.topf, satpos.sat.key.len,
+				satpos.sat.offs, satpos.sat.fmap);
+			gws.advanceElement((TIndexOffU)elt, ebwtFw, ref, sa, gwstate_, wr, prm);
+			assert_neq(OFF_MASK, wr.toff);
+
+			TIndexOffU tidx = 0, toff = 0, tlen = 0;
+			bool straddled = false;
+			ebwtFw.joinedToTextOff(wr.elt.len, wr.toff, tidx, toff, tlen,
+			                       false, straddled);
+
+			int64_t refoff = (int64_t)toff - rdoff;
+			Coord refcoord(tidx, refoff, fw);
+			if(seenDiags1_.locusPresent(refcoord)) {
+				prm.nRedundants++;
+				continue;
+			}
+
+			DPRect rect;
+			bool found = dpframe.frameSeedExtensionRect(
+				refoff, rows, tlen, readGaps, refGaps,
+				(size_t)nceil, maxhalf, rect);
+			assert(rect.repOk());
+			seenDiags1_.add(Interval(refcoord, 1));
+			if(!found) continue;
+
+			size_t nwindow = 0;
+			if((int64_t)toff >= rect.refl) {
+				nwindow = (size_t)(toff - rect.refl);
+			}
+
+			ExtendCandidate cand;
+			cand.fw       = fw;
+			cand.tidx     = tidx;
+			cand.toff     = toff;
+			cand.tlen     = tlen;
+			cand.refoff   = refoff;
+			cand.rect     = rect;
+			cand.nwindow  = nwindow;
+			cand.refcoord = refcoord;
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+			cand.lrm11_passed = false;
+			// Write profbuf/rf/gaps/nrow directly into pre-allocated flat arrays.
+			if(cands.size() < ALN_MAX_ITER) {
+				const size_t flat_idx = cand_offset + cands.size();
+				const size_t rf_stride = ALN_MAX_COLS + 2;
+				flat_mate[flat_idx] = (uint32_t)mate_idx * 2 + (fw ? 0 : 1);
+				size_t nsInLeftShift = 0;
+				bool ok = swa.initRef(
+					fw, tidx, rect, ref,
+					tlen, minsc, true /*enable8*/,
+					true /*extend*/,
+					nwindow, nsInLeftShift);
+				if(ok) {
+					uint16_t rflen = 0, nrow = 0;
+					swa.fillCandRf(
+						flat_rf + flat_idx * rf_stride,
+						rflen, nrow);
+					flat_rflen[flat_idx] = rflen;
+					flat_nrow [flat_idx] = nrow;
+				} else {
+					flat_rflen[flat_idx] = 0;
+					flat_nrow [flat_idx] = 0;
+				}
+			} // if cands.size() < ALN_MAX_ITER
+#else
+			cand.lrm11_passed = true;  // filter disabled; all candidates pass
+#endif
+			cands.push_back(cand);
+		}
+	}
+
+	return EXTEND_EXHAUSTED_CANDIDATES; // collect never fulfils policy itself
+}
+
+
+/*
+ * Alignment for seeds. Forms the DP, retrieiving the best scoring alignments and backtracing
+ */
+int SwDriver::extendSeedsAlign(
+	EList<ExtendCandidate>& cands,
+	const BitPairReference& ref,
+	SwAligner& swa,
+	const Scoring& sc,
+	const int seedmms,
+	const int seedlen,
+	const int seedival,
+	const TAlScore minsc,
+	const bool enable8,
+	PerReadMetrics& prm,
+	AlnSinkWrap* msink,
+	bool reportImmediately,
+	bool& exhaustive)
+{
+	assert(!reportImmediately || msink != NULL);
+	assert(!reportImmediately || !msink->maxed());
+
+	for(size_t ci = 0; ci < cands.size(); ci++) {
+		ExtendCandidate& cand = cands[ci];
+
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+		if(!cand.lrm11_passed) continue;
+#endif
+
+		size_t nsInLeftShift = 0;
+		if(!swa.initRef(
+			cand.fw, cand.tidx, cand.rect, ref,
+			cand.tlen, minsc, enable8,
+			true,  // seed extension (not mate finding)
+			cand.nwindow, nsInLeftShift))
+		{
+			prm.nExDpFails++;
+			prm.nDpFail++;
+			return EXTEND_EXCEEDED_HARD_LIMIT;
+		}
+
+		Interval refival(cand.tidx, 0, cand.fw, 0);
+		cand.rect.initIval(refival); // const_cast-safe: rect is our own copy
+		seenDiags1_.add(refival);
+
+		TAlScore bestCell = std::numeric_limits<TAlScore>::min();
+		bool found = swa.align(bestCell);
+		prm.nExDps++;
+		if(!found) {
+			prm.nExDpFails++;
+			prm.nDpFail++;
+			if(bestCell > std::numeric_limits<TAlScore>::min() &&
+			   bestCell > prm.bestLtMinscMate1) {
+				prm.bestLtMinscMate1 = bestCell;
+			}
+			continue;
+		}
+		prm.nExDpSuccs++;
+		prm.nDpLastSucc = prm.nExDps - 1;
+		if(prm.nDpFail > prm.nDpFailStreak) prm.nDpFailStreak = prm.nDpFail;
+		prm.nDpFail = 0;
+
+		while(true) {
+			resGap_.reset();
+			assert(resGap_.empty());
+			if(swa.done()) break;
+			swa.nextAlignment(resGap_, minsc);
+			found = !resGap_.empty();
+			if(!found) break;
+
+			SwResult* res = &resGap_;
+			Interval refival2(cand.tidx, 0, cand.fw, cand.tlen);
+			assert_gt(res->alres.refExtent(), 0);
+			if(reportOverhangs &&
+			   !refival2.containsIgnoreOrient(res->alres.refival()))
+			{
+				res->alres.clipOutside(true, 0, cand.tlen);
+				if(res->alres.refExtent() == 0) continue;
+			}
+			if(!refival2.overlapsIgnoreOrient(res->alres.refival())) continue;
+			if(redAnchor_.overlap(res->alres)) continue;
+			redAnchor_.add(res->alres);
+			res->alres.setParams(seedmms, seedlen, seedival, minsc);
+
+			if(reportImmediately) {
+				assert(msink != NULL);
+				assert(res->repOk());
+				assert(!msink->maxed());
+				if(msink->report(0, &res->alres, NULL)) {
+					return EXTEND_POLICY_FULFILLED;
+				}
+			}
+		}
+	}
+
+	return EXTEND_EXHAUSTED_CANDIDATES;
+}
+
 #ifdef SUPPORT_PAIRED
 // NOTE: Unsupported, likely does not work
 

--- a/aligner_sw_driver.h
+++ b/aligner_sw_driver.h
@@ -211,6 +211,27 @@ struct ExtendRange {
 	size_t sz;  // # of elements in SA range
 };
 
+/**
+ * One DP problem collected during the BWT-walk phase of extendSeedsCollect.
+ * Contains everything needed by extendSeedsAlign to run initRef + align
+ * without touching the BWT index again.
+ *
+ * The profbuf/rf/rflen/nrow/gaps fields are pre-populated by extendSeedsCollect
+ * so that the LRM11Scalar pre-filter can run on the pre-decoded data directly,
+ * without accessing BitPairReference (CPU-only memory-mapped data).
+ */
+struct ExtendCandidate {
+	bool           fw;        // alignment orientation
+	TIndexOffU     tidx;      // reference sequence index
+	TIndexOffU     toff;      // offset within reference sequence
+	TIndexOffU     tlen;      // length of reference sequence
+	int64_t        refoff;    // ref offset implied by seed (no gaps)
+	DPRect         rect;      // DP bounding rectangle
+	size_t         nwindow;   // left-shift of seed within rect
+	Coord          refcoord;  // seed coordinate (for seenDiags bookkeeping)
+	bool           lrm11_passed; // passed LRM11Scalar pre-filter; set by runLRM11Filter
+};
+
 class SwDriver {
 
 public:
@@ -284,6 +305,60 @@ public:
 		AlnSinkWrap* mhs,            // HitSink for multiseed-style aligner
 		bool reportImmediately,      // whether to report hits immediately to mhs
 		bool& exhaustive);
+
+	/**
+	 * Phase 1 of the split extendSeeds pipeline.
+	 * Walks the BWT, resolves reference offsets, frames DP rectangles, and
+	 * collects surviving candidates into `cands`.
+	 * Returns EXTEND_PERFECT_SCORE early if minsc == perfectScore.
+	 */
+	int extendSeedsCollect(
+		const Ebwt& ebwtFw,          // BWT
+		const BitPairReference& ref, // Reference strings
+		SwAligner& swa,              // used only to query dpRows()
+		const Scoring& sc,           // scoring scheme
+		const int seedmms,           // # mismatches allowed in seed
+		const int seedlen,           // length of seed
+		const int seedival,          // interval between seeds
+		const TAlScore minsc,        // minimum score for anchor
+		const int nceil,             // maximum # Ns permitted in ref portion
+		const size_t maxhalf,        // maximum width on one side of DP table
+		PerReadMetrics& prm,           // per-read metrics
+		EList<ExtendCandidate>& cands  // output: DP problems to solve
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+		, uint32_t       mate_idx,     // index of this mate in flat_profbuf/flat_gaps/flat_minsc
+		size_t         cand_offset,    // where in flat rf/rflen/nrow this mate's candidates start
+		uint8_t*       flat_profbuf,   // [num_mates * ALPHA_SIZE * ALN_MAX_ROWS * 2]
+		char*          flat_rf,        // [total_cap * (ALN_MAX_COLS + 2)]
+		int8_t*        flat_gaps,      // [num_mates * 4]
+		uint16_t*      flat_rflen,     // [total_cap]
+		uint16_t*      flat_nrow,      // [total_cap]
+		uint32_t*      flat_mate       // [total_cap] — candidate → mate index
+#endif
+		);
+
+	/**
+	 * Phase 2 of the split extendSeeds pipeline.
+	 * For each candidate collected by extendSeedsCollect, runs initRef +
+	 * align + nextAlignment + report.  `swa` must already have initRead
+	 * called on it.
+	 * Returns EXTEND_POLICY_FULFILLED if a reporting limit is hit, or
+	 * EXTEND_EXHAUSTED_CANDIDATES when all candidates are processed.
+	 */
+	int extendSeedsAlign(
+		EList<ExtendCandidate>& cands,       // candidates from collect phase
+		const BitPairReference& ref, // Reference strings
+		SwAligner& swa,              // dynamic programming aligner (initRead already called)
+		const Scoring& sc,           // scoring scheme
+		const int seedmms,           // # mismatches allowed in seed
+		const int seedlen,           // length of seed
+		const int seedival,          // interval between seeds
+		const TAlScore minsc,        // minimum score for anchor
+		const bool enable8,          // use 8-bit SSE where possible
+		PerReadMetrics& prm,         // per-read metrics
+		AlnSinkWrap* msink,          // HitSink for multiseed-style aligner
+		bool reportImmediately,      // whether to report hits immediately to msink
+		bool& exhaustive);           // set to true iff all candidates processed
 
 #ifdef SUPPORT_PAIRED
 // NOTE: Unsupported, likely does not work

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -344,13 +344,23 @@ inline void EEU8_lazyF(const SSERegI vf0,
  * Solve the current alignment problem using SSE instructions that operate on 16
  * unsigned 8-bit values packed into a single 128-bit register.
  *
- * Select intput parameters:
+ * When score_only=true: runs the full DP but ping-pongs over two columns in
+ * pmat instead of writing a new column per reference position.  Returns lrmax
+ * and populates btncand with every column whose last-row score meets minsc,
+ * but does NOT store the full E/F/H matrix needed for backtrace.
+ *
+ * When score_only=false: writes a new matrix column for each reference
+ * position up to rfd, storing E/F/H vectors required for backtrace.
+ *
+ * Select input parameters:
  *   profbuf - buffer for query profile & temp vecs
  *   rf      - reference sequence
+ *   rfd     - number of reference columns to process
  *
  * Select output parameters:
- *   pmat    - SSE matrix for holding all E, F, H vectors
- *   btncand - cells we might backtrace from
+ *   pmat    - SSE matrix; used as 2-column ping-pong scratch when score_only,
+ *             or filled column-by-column otherwise
+ *   btncand - cells we might backtrace from (populated in both modes)
  */
 template<typename TIdxSize>
 inline EEU8_TCScore EEU8_alignNucleotides(const SSERegI profbuf[],
@@ -997,6 +1007,81 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRM11Scalar(const uint8_t profbuf[],
 }
 
 #ifndef SWSSE_INLINE_ONLY
+/**
+ * Run only the LRM11Scalar pre-filter for the current initRef state.
+ * Returns true if the best last-row score meets minsc (candidate may align),
+ * false if it definitely cannot (safe to skip full DP).
+ */
+bool SwAligner::filterLRM11(TAlScore minsc) {
+	assert(initedRef() && initedRead());
+	buildQueryProfileEnd2EndSseU8(fw_);
+	auto& d = fw_ ? sseU8fw_ : sseU8rc_;
+	const size_t iter = (dpRows() + (EEU8_NWORDS_PER_REG-1)) / EEU8_NWORDS_PER_REG;
+	if(iter != 151) return true; // filter undefined for this read length; pass through
+	const EEU8_TCScore lrmax = EEU8_alignNucleotidesLRM11Scalar<uint16_t, 151, 5>(
+		reinterpret_cast<const uint8_t*>(d.profbuf_.ptr()), rf_, rflen_,
+		dpRows(),
+		sc_->refGapOpen(), sc_->refGapExtend(), sc_->readGapOpen(), sc_->readGapExtend());
+	return (TAlScore)(lrmax - 0xff) >= minsc;
+}
+
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+void SwAligner::runLRM11Filter(
+	int             total_cands,
+	int             num_mates,
+	const uint8_t*  flat_profbuf, // [num_mates*2*pb_stride]: slot mate*2+0=fw, mate*2+1=rc
+	const char*     flat_rf,
+	const int8_t*   flat_gaps,    // [num_mates*4]
+	const uint16_t* flat_rflen,
+	const uint16_t* flat_nrow,
+	const int32_t*  flat_minsc,   // [num_mates]
+	const uint32_t* flat_mate,    // [total_cands]: mate*2+(fw?0:1), indexes profbuf directly
+	bool*           flat_passed)
+{
+	const int npar = std::min(total_cands, 16384);
+	const int elp_pp = (total_cands + npar - 1) / npar;
+	const size_t pb_stride = ALPHA_SIZE * ALN_MAX_ROWS * 2;
+	const size_t rf_stride = ALN_MAX_COLS + 2;
+#ifdef OMPGPU
+#pragma omp target teams distribute \
+	map(to: flat_profbuf[0:num_mates*2*pb_stride], \
+	        flat_rf[0:total_cands*rf_stride], \
+	        flat_gaps[0:num_mates*4], \
+	        flat_rflen[0:total_cands], \
+	        flat_nrow[0:total_cands], \
+	        flat_minsc[0:num_mates], \
+	        flat_mate[0:total_cands]) \
+	map(tofrom: flat_passed[0:total_cands])
+#else
+#pragma omp parallel for schedule(dynamic)
+#endif
+	for(int p = 0; p < npar; p++) {
+		const int iend = std::min((p + 1) * elp_pp, total_cands);
+#ifdef OMPGPU
+#pragma omp parallel for
+#endif
+		for(int ci = p * elp_pp; ci < iend; ci++) {
+			if(flat_rflen[ci] == 0 || flat_nrow[ci] != 151) {
+				flat_passed[ci] = (flat_nrow[ci] != 151);
+			} else {
+				// flat_mate[ci] = mate*2 + (fw?0:1): direct index into profbuf (fw vs rc slot).
+				// Shift right to get the mate index for gaps and minsc.
+				const uint32_t pb_slot = flat_mate[ci];
+				const uint32_t mate    = pb_slot >> 1;
+				const EEU8_TCScore lrmax = EEU8_alignNucleotidesLRM11Scalar<uint16_t, 151, 5>(
+					flat_profbuf + (size_t)pb_slot * pb_stride,
+					flat_rf      + (size_t)ci * rf_stride,
+					flat_rflen[ci],
+					flat_nrow[ci],
+					flat_gaps[mate*4+0], flat_gaps[mate*4+1],
+					flat_gaps[mate*4+2], flat_gaps[mate*4+3]);
+				flat_passed[ci] = ((TAlScore)(lrmax - 0xff) >= (TAlScore)flat_minsc[mate]);
+			}
+		}
+	}
+}
+#endif
+
 /**
  * Align read 'rd' to reference using read & reference information given
  * last time init() was called.

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -2275,6 +2275,7 @@ public:
 
 	SwDriverBT2 sd;
 	RandomSource rnd;
+	EList<ExtendCandidate> extend_cands; // filled by extendSeedsCollect, consumed by extendSeedsAlign
 
 };
 
@@ -2452,6 +2453,31 @@ static void multiseedSearchWorker() {
 #ifdef USE_CUSTOM_ALLOCS
 		// Maybe: Consider doing set_alloc for batch objects, too
 		for (uint32_t mate=0; mate<num_parallel_tasks; mate++) g_msobjs[mate].set_alloc(&(mate_allocs[mate]));
+#endif
+
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+		// Pre-allocate flat arrays for LRM11 filter once per run.
+		// ALN_MAX_ITER is the hard cap on candidates per mate (enforced in extendSeedsCollect).
+		const size_t flat_per_mate  = ALN_MAX_ITER;
+		const size_t flat_cap       = (size_t)num_parallel_tasks * flat_per_mate;
+		const size_t flat_pb_stride = ALPHA_SIZE * ALN_MAX_ROWS * 2;
+		const size_t flat_rf_stride = ALN_MAX_COLS + 2;
+		// profbuf has two slots per mate: [mate*2+0]=fw, [mate*2+1]=rc.
+		// flat_mate[ci] = mate*2 + (fw?0:1); kernel uses it directly to index profbuf.
+		// flat_gaps and flat_minsc are indexed by mate (= flat_mate[ci]>>1).
+		uint8_t*  flat_profbuf = new uint8_t [num_parallel_tasks * 2 * flat_pb_stride];
+		char*     flat_rf      = new char    [flat_cap * flat_rf_stride];
+		int8_t*   flat_gaps    = new int8_t  [num_parallel_tasks * 4];
+		uint16_t* flat_rflen   = new uint16_t[flat_cap];
+		uint16_t* flat_nrow    = new uint16_t[flat_cap];
+		int32_t*  flat_minsc   = new int32_t [flat_cap];
+		uint32_t* flat_mate    = new uint32_t[flat_cap]; // candidate → mate index
+		bool*     flat_passed  = new bool    [flat_cap];
+		// mate i owns candidate slots [mate_cand_offset[i], mate_cand_offset[i] + flat_per_mate)
+		size_t*   mate_cand_offset = new size_t[num_parallel_tasks];
+		for(uint32_t mate = 0; mate < num_parallel_tasks; mate++) {
+			mate_cand_offset[mate] = (size_t)mate * flat_per_mate;
+		}
 #endif
 
 		assert(multiseedMms==0);
@@ -2803,11 +2829,16 @@ static void multiseedSearchWorker() {
 		 	mate_allocs.ensure_spare();
 #endif
 
-		   	// we can do all of the "mates" in parallel
+		   	// Phase 1: BWT walk — resolve SA offsets to ref coordinates, frame DP rects.
+		   	// Serial within each mate's SwDriver (gws_ state), parallel across mates.
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+		   	// Zero flat_rflen before collect so stale slots from the previous batch
+		   	// are skipped by the filter (rflen==0 -> kernel skips the slot).
+			// The candidate check iteration runs on the cpu and is pretty fast
+		   	memset(flat_rflen, 0, flat_cap * sizeof(uint16_t));
+#endif
 #pragma omp parallel for default(shared)
 			for (uint32_t nb=0; nb<batch_parallel_tasks; nb++) {
-			   // These objects are really just work areas
-			   // Could have just created them here, but this way we minimize mallocs
 			   bcWorkerObjs& bcobj = g_bcobjs[nb];
 			   SwAligner &sw = bcobj.sw;
 
@@ -2815,68 +2846,152 @@ static void multiseedSearchWorker() {
 				const uint32_t mate = nb*reads_per_batch + ib;
 				if (mate_idx[mate]>=0 ) { // !done[mate]
 					msWorkerObjs& msobj = g_msobjs[mate];
-					AlnSinkWrapOne& msinkwrap = g_msinkwrap[mate]; 
-					const uint16_t interval = intervals[mate];
+					AlnSinkWrapOne& msinkwrap = g_msinkwrap[mate];
 					Read& rd = *rds[mate];
 					const size_t rdlen = rd.length();
-					// Initialize the aligner with a new read
 					sw.reset();
 					if (!sw.initRead(
-						rd.patFw,  // fw version of query
-						rd.patRc,  // rc version of query
-						rd.qual,   // fw version of qualities
-						rd.qualRev,// rc version of qualities
-						rdlen,     // off of last char (excl) in 'rd' to consider
-						msconsts->sc)) {     // scoring scheme
-								// Something went terribly wrong (likely read too long)
-								// Bail out
-								mate_idx[mate] = MATE_DONE;
+						rd.patFw,  rd.patRc,
+						rd.qual,   rd.qualRev,
+						rdlen,     msconsts->sc)) {
+						mate_idx[mate] = MATE_DONE;
 					} else {
-						const SeedResults& sh = psrs->getSR(mate);
-
-
-								// Unpaired dynamic programming driver
-								int ret = msobj.sd.extendSeeds(
-										sh,             // seed hits
-										msconsts->ebwtFw,         // bowtie index
-										msconsts->ref,            // packed reference strings
-										sw,                       // dynamic prog aligner
-										msconsts->sc,             // scoring scheme
-										multiseedMms,   // # mms allowed in a seed
-										multiseedLen,   // length of a seed
-										interval,       // interval between seeds
-										minsc[mate],    // minimum score for valid
-										nceil[mate],    // N ceil for anchor
-										msconsts->maxHalf,        // max width on one DP side
-										msconsts->extend,       // extend seed hits
-										msconsts->doEnable8,        // use 8-bit SSE where possible
-										msinkwrap.prm,  // per-read metrics
-										&msinkwrap,     // for organizing hits
-										true,           // report hits once found
-										exhaustive[mate]);
-								assert_gt(ret, 0);
-								if ((ret == EXTEND_EXHAUSTED_CANDIDATES) ||
-								     (ret == EXTEND_EXCEEDED_SOFT_LIMIT) ||
-                                                                     (ret == EXTEND_POLICY_FULFILLED)) {
-									// Not done yet
-									
-									// We don't necessarily have to continue investigating both
-									// mates.  We continue on a mate only if its average
-									// interval length is high (> 1000)
-									if(psrs->getSR(mate).averageHitsPerSeed() < seedBoostThresh) {
-										mate_idx[mate] = MATE_DONE;
-									} else if(msinkwrap.state().doneWithMate(true)) {
-										mate_idx[mate] = MATE_DONE;
-									}
-								} else {
-									mate_idx[mate] = MATE_DONE;
-								}
-
-					} // if initRead
-				} // if mate done
+						int ret = msobj.sd.extendSeedsCollect(
+							msconsts->ebwtFw,
+							msconsts->ref,
+							sw,
+							msconsts->sc,
+							multiseedMms,
+							multiseedLen,
+							intervals[mate],
+							minsc[mate],
+							nceil[mate],
+							msconsts->maxHalf,
+							msinkwrap.prm,
+							msobj.extend_cands
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+							, (uint32_t)mate,
+							mate_cand_offset[mate],
+							flat_profbuf, flat_rf,
+							flat_gaps, flat_rflen, flat_nrow,
+							flat_mate
+#endif
+							);
+						if (ret == EXTEND_PERFECT_SCORE) {
+							mate_idx[mate] = MATE_DONE;
+						}
+					}
+				} // if mate active
 			   } // for ib
 			} // for nb
-		   tmr.next("extendSeeds");
+		   tmr.next("extend_bwtwalk");
+
+		   // always call ensure_spare from main CPU thread
+#ifdef USE_CUSTOM_ALLOCS
+		   mate_allocs.ensure_spare();
+#endif
+
+		   	// Phase 1b: Optional LRM11Scalar pre-filter, mark which candidates *may* align.
+		   	// Completely optional method. This can be used if we believe the candidates can be
+			// calculated faster than it takes to actually calculate the score
+		   	// profbuf/rf/gaps/nrow were written into flat arrays by extendSeedsCollect.
+		   	// Fill minsc/passed scalars and dispatch the filter (GPU or CPU).
+#ifdef PRE_LR_SCALAR
+			{
+				const uint32_t total_mates = batch_parallel_tasks * reads_per_batch;
+
+				// Fill flat_minsc per mate (one value covers all its candidates).
+				uint32_t total_cands = 0;
+				for(uint32_t mate = 0; mate < total_mates; mate++) {
+					if(mate_idx[mate] < 0) continue;
+					msWorkerObjs& msobj = g_msobjs[mate];
+					flat_minsc[mate] = (int32_t)minsc[mate];
+					total_cands += (uint32_t)msobj.extend_cands.size();
+				}
+
+				if(total_cands > 0) {
+					// Run LRM11 filter over all active candidate slots.
+					// Inactive slots (flat_rflen==0) are skipped by the kernel.
+					SwAligner::runLRM11Filter(
+						(int)flat_cap,
+						(int)num_parallel_tasks,
+						flat_profbuf, flat_rf, flat_gaps,
+						flat_rflen, flat_nrow, flat_minsc,
+						flat_mate, flat_passed);
+
+					// Scatter results back to per-mate candidate lists.
+					for(uint32_t mate = 0; mate < total_mates; mate++) {
+						if(mate_idx[mate] < 0) continue;
+						msWorkerObjs& msobj = g_msobjs[mate];
+						const size_t off = mate_cand_offset[mate];
+						for(size_t ci = 0; ci < msobj.extend_cands.size(); ci++) {
+							msobj.extend_cands[ci].lrm11_passed = flat_passed[off + ci];
+						}
+					}
+				}
+			}
+		   tmr.next("calculate_candidates");
+		   // always call ensure_spare from main CPU thread
+#ifdef USE_CUSTOM_ALLOCS
+		   mate_allocs.ensure_spare();
+#endif
+#endif // PRE_LR_SCALAR
+
+		   	// Phase 2: DP + backtrace — run SSE Smith-Waterman on passing candidates.
+		   	// Each mate's candidates are independent; parallel across mates.
+#pragma omp parallel for default(shared)
+			for (uint32_t nb=0; nb<batch_parallel_tasks; nb++) {
+			   bcWorkerObjs& bcobj = g_bcobjs[nb];
+			   SwAligner &sw = bcobj.sw;
+
+			   for (uint16_t ib=0; ib<reads_per_batch; ib++) {
+				const uint32_t mate = nb*reads_per_batch + ib;
+				if (mate_idx[mate]>=0 ) { // !done[mate]
+					msWorkerObjs& msobj = g_msobjs[mate];
+					AlnSinkWrapOne& msinkwrap = g_msinkwrap[mate];
+					Read& rd = *rds[mate];
+					const size_t rdlen = rd.length();
+					// Re-initialize sw for this mate: initRead state is per-worker,
+					// but sw is shared and was last set for whichever mate ran last
+					// in Phase 1 on this worker. Omit reset() to preserve pmat_
+					// layout, avoiding non-deterministic backtrace tie-breaking.
+					if(!sw.initRead(
+						rd.patFw,  rd.patRc,
+						rd.qual,   rd.qualRev,
+						rdlen,     msconsts->sc)) {
+						mate_idx[mate] = MATE_DONE;
+						continue;
+					}
+					int ret = msobj.sd.extendSeedsAlign(
+							msobj.extend_cands,
+							msconsts->ref,
+							sw,
+							msconsts->sc,
+							multiseedMms,
+							multiseedLen,
+							intervals[mate],
+							minsc[mate],
+							msconsts->doEnable8,
+							msinkwrap.prm,
+							&msinkwrap,
+							true,           // report hits once found
+							exhaustive[mate]);
+					assert_gt(ret, 0);
+					if ((ret == EXTEND_EXHAUSTED_CANDIDATES) ||
+					    (ret == EXTEND_EXCEEDED_SOFT_LIMIT)  ||
+					    (ret == EXTEND_POLICY_FULFILLED)) {
+						if(psrs->getSR(mate).averageHitsPerSeed() < seedBoostThresh) {
+							mate_idx[mate] = MATE_DONE;
+						} else if(msinkwrap.state().doneWithMate(true)) {
+							mate_idx[mate] = MATE_DONE;
+						}
+					} else {
+						mate_idx[mate] = MATE_DONE;
+					}
+				} // if mate active
+			   } // for ib
+			} // for nb
+		   tmr.next("extend_dp_backtrace");
 
 		   // always call ensure_spare from main CPU thread
 #ifdef USE_CUSTOM_ALLOCS
@@ -2951,6 +3066,16 @@ static void multiseedSearchWorker() {
 		delete[] minsc;
 		delete[] g_msobjs;
 		delete[] g_bcobjs;
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+		delete[] mate_cand_offset;
+		delete[] flat_passed;
+		delete[] flat_minsc;
+		delete[] flat_nrow;
+		delete[] flat_rflen;
+		delete[] flat_gaps;
+		delete[] flat_rf;
+		delete[] flat_profbuf;
+#endif
 
 		// do not delete objects managed by the allocator
 		// accept memory leak


### PR DESCRIPTION
Separated extendSeeds into steps:
    1. BWT search/walk 
    1b. Optional search for candidates
    2. DP Calculation (original kernel) + DP backtrace When 1b is used all DP Calculations will have candidates for a backtrace

Flattening of memory for seedextend for 1b to work

-p 1600 works, but bigger numbers sometimes leads to Out of Memory Issues

Working State of LRMask first

Note that same alignment buts different file outputs

In a pure PRE_LR_SCALAR SSE_SCALAR with CPU/GPU OpenMP:

Timer: 0                      19.90917637 read
Timer: 1                       0.30658882 instantiateSeeds
Timer: 2                       0.15544169 searchAllSeedsPrepare
Timer: 3                       7.37917849 searchAllSeedsDo
Timer: 4                       0.27009717 searchAllSeedsFinalize
Timer: 5                       0.42531317 prioritizeSATups
Timer: 6                      37.19392671 extend_bwtwalk      (Strangely I've seen this swing from 20s to this. I think with p count)
Timer: 7                       6.06212484 calculate_candidates (This is shockingly fast?! With 96% of them being discarded here) Run on GPU.
Timer: 8                     121.08206529 extend_dp_backtrace  (This one should run on CPU SSE_SCALAR, which is correctly slow. With AVX2 that time should shut down.)
Timer: 9                      16.99168865 finishReadOne
1479006 reads; of these:
  1479006 (100.00%) were unpaired; of these:
    473516 (32.02%) aligned 0 times
    125995 (8.52%) aligned exactly 1 time
    879495 (59.47%) aligned >1 times
67.98% overall alignment rate

Alignment rates match up.