### PR TITLE
Add GPU full-alignment variant - EEU8_alignNucleotidesM11Scalar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,13 +54,14 @@ CXX := amdclang++
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DCPUVECT -DUSE_BUILTIN_SUB_SAT -march=native
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR
-CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
+CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2 -DBUILTIN_SUB_SAT_BROKEN
 
 #
 # GPU-enabled
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm  -Rpass-analysis=kernel-resource-usage
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage -DBUILTIN_SUB_SAT_BROKEN
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_M11_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage -DBUILTIN_SUB_SAT_BROKEN
 
 # Enable HIP. Use CXX=amdclang++ or CXX=hipcc 
 # Warning with hybrid OPENMP Compilations

--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,14 @@ CXX := amdclang++
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DCPUVECT -DUSE_BUILTIN_SUB_SAT -march=native
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR
-CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2 -DBUILTIN_SUB_SAT_BROKEN
+CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
 
 #
 # GPU-enabled
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm  -Rpass-analysis=kernel-resource-usage
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage -DBUILTIN_SUB_SAT_BROKEN
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_M11_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage -DBUILTIN_SUB_SAT_BROKEN
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_M11_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
 
 # Enable HIP. Use CXX=amdclang++ or CXX=hipcc 
 # Warning with hybrid OPENMP Compilations

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -1272,6 +1272,263 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRM11Scalar(const uint8_t profbuf[],
 	return lrmax;
 }
 
+/* 
+ * Like EEU8_alignNucleotidesLRM11Scalar, but actually saves E,F,H, too 
+ * That said, it uses a different output layout, to improve write coalescing
+ */
+template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151, uint16_t MAX_RB=5, uint32_t VSize=64>
+inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
+					const char   rf[], const TIdxSize rfd,
+					uint8_t pmat[],
+					const size_t nrow,
+					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
+        class TPackedScore {
+	private:
+		uint8_t val;
+		// vs0 or vs1 (score) encoded to a bit: 0->0x00, 1->0x01
+		static constexpr uint8_t decode_bit(uint8_t val, uint8_t shift) { return (val>>shift) & 0x1; }
+		static constexpr uint8_t encode1(uint8_t v) { return v != 0 ? 1u : 0u; }
+
+	public:
+		constexpr TPackedScore() : val(0) {};
+		constexpr TPackedScore(const uint8_t packed_val) : val(packed_val) {};
+
+		constexpr TPackedScore(const TPackedScore& other) : val(other.val) {}
+		constexpr TPackedScore& operator=(const TPackedScore& other) { val = other.val; return *this;}
+
+		// Pack one full byte from profbuf: pe0[0..3] into bits 0-3, pe1[0..3] into bits 4-7.
+		// pe0 points to j-pair0 (4 bytes: vs0_even, vs1_even, vs0_odd, vs1_odd),
+		// pe1 points to j-pair1 (same layout, offset +4).
+		static constexpr uint8_t pack_full(const uint8_t *pe0, const uint8_t *pe1) {
+			return  encode1(pe0[0])        |
+			       (encode1(pe0[1]) << 1)  |
+			       (encode1(pe0[2]) << 2)  |
+			       (encode1(pe0[3]) << 3)  |
+			       (encode1(pe1[0]) << 4)  |
+			       (encode1(pe1[1]) << 5)  |
+			       (encode1(pe1[2]) << 6)  |
+			       (encode1(pe1[3]) << 7);
+		}
+
+		// Pack a remainder byte from profbuf: between 1 and 3 j-steps from pe0 (and optionally pe1).
+		// nsteps is the number of remaining j-steps (1, 2, or 3).
+		static constexpr uint8_t pack_remainder(const uint8_t *pe0, const uint8_t *pe1, int nsteps) {
+			uint8_t packed = encode1(pe0[0]) | (encode1(pe0[1]) << 1);
+			if (nsteps >= 2)
+				packed |= (encode1(pe0[2]) << 2) | (encode1(pe0[3]) << 3);
+			if (nsteps >= 3)
+				packed |= (encode1(pe1[0]) << 4) | (encode1(pe1[1]) << 5);
+			return packed;
+		}
+
+		// note that vs1 is a cell's bias E/F score, vs0 is a cell's bias H score
+		// They are paired together and multiple are packed into a byte
+		// vs1 scores are packed at odd indices
+		constexpr uint8_t get_score(uint8_t j_mod) const {
+			uint8_t score = decode_bit(val, j_mod);
+
+			// vs1 should be 0xff (mask) or 0x00, not {0x00 or 0x01}
+			// An odd j_mod means it is a vs1 score
+			if(j_mod % 2 != 0) {
+				score = -score;
+				//Because score={0x00,0x01} it is equivalent to:
+				//score = (score) ? 0xff : 0x00;
+			}
+
+			return score;
+		};
+
+		constexpr uint8_t operator()() const {return val;}
+	};
+
+        class TPackedEH {
+	private:
+		uint32_t val;
+	public:
+		constexpr TPackedEH() : val(0) {};
+		constexpr TPackedEH(const TPackedEH& other) : val(other.val) {}
+		constexpr TPackedEH& operator=(const TPackedEH& other) { val = other.val; return *this;}
+
+		constexpr uint8_t get_byte(int i) const { return uint8_t(val >> (i * 8)); }
+		constexpr void set_bytes(int i, uint8_t E, uint8_t H) {
+			const uint32_t mask = uint32_t(0xffffU) << (i * 16);
+			val = (val & ~mask) | ((uint32_t(H) << (i*16 + 8)) | (uint32_t(E) << (i*16)));
+		}
+
+		// i=0 addresses the even slot, i=1 the odd slot.
+		constexpr uint8_t get_E(int i) const { return get_byte(i * 2); }
+		constexpr uint8_t get_H(int i) const { return get_byte(i * 2 + 1); }
+
+		// Apply one j-step. score_off is the logical index within the packed byte (0-3).
+		// score_off is always a compile-time literal so all branches are eliminated.
+		inline void apply_step(const TPackedScore &full_score, int score_off,
+				       uint8_t pmat[],
+		                       uint8_t &vf, uint8_t &vh,
+		                       uint8_t rdgapo, uint8_t rdgape,
+		                       uint8_t rfgapo, uint8_t rfgape) {
+			const int i = score_off % 2;
+
+			// Load cells from E and H, calculated previously
+			uint8_t ve        = get_E(i);
+			uint8_t vh_next   = get_H(i);
+			const uint8_t vs0 = full_score.get_score(score_off*2);
+			const uint8_t vs1 = full_score.get_score(score_off*2+1);
+
+			// Store cells in F, calculated previously
+			vf = subs_u8(vf, vs1); // veto some ref gap extensions
+
+			// save F
+			pmat[0] = vf;
+
+			// Factor in query profile (matches and mismatches)
+			vh = subs_u8(vh, vs0);
+
+			// Update H, factoring in E and F
+			vh = std::max(vh, ve);
+			vh = std::max(vh, vf);
+
+			// save H
+			pmat[VSize] = vh;
+
+			// Save the new vH values
+			uint8_t vtmp = vh;
+
+			// Update vE value
+			vh = subs_u8(vh, rdgapo);
+			vh = subs_u8(vh, vs1); // veto some read gap opens
+			ve = subs_u8(ve, rdgape);
+			ve = std::max(ve, vh);
+
+			// save E
+			pmat[2*VSize] = ve;
+
+			// Save E and H values for next i round
+			set_bytes(i, ve, vtmp);
+
+			// Update vf value
+			vtmp = subs_u8(vtmp, rfgapo);
+			vf = subs_u8(vf, rfgape);
+			vf = std::max(vf, vtmp);
+
+			// Load the next H value
+			vh = vh_next;
+		}
+	};
+
+        constexpr uint16_t iter = MAX_ITER;
+
+	assert_gt(refGapOpen, 0);
+	uint8_t rfgapo = uint8_t(refGapOpen);
+	
+	// Set all elts to reference gap extension penalty
+	assert_gt(refGapExtend, 0);
+	assert_leq(refGapExtend, refGapOpen);
+	uint8_t rfgape = uint8_t(refGapExtend);
+
+	// Set all elts to read gap open penalty
+	assert_gt(readGapOpen, 0);
+	uint8_t rdgapo = uint8_t(readGapOpen);
+	
+	// Set all elts to read gap extension penalty
+	assert_gt(readGapExtend, 0);
+	assert_leq(readGapExtend, readGapOpen);
+	uint8_t rdgape = uint8_t(readGapExtend);
+
+	// Load the procbuf, E/F and H biases, into local memory, compacting {0x00, non-zero} -> {0, 1} (1-bit encoding).
+	// Each byte packs two consecutive j-pairs (4 j-steps) into one byte.
+	// The last byte covers any remainder j-pairs that don't fill a full byte.
+	uint8_t loc_procbuf[MAX_RB][(MAX_ITER+3)/4];
+	for (int ir = 0; ir < MAX_RB; ir++) {
+		const uint8_t *pvScore = profbuf + (size_t)ir * iter * 2;
+		for (TIdxSize b = 0; b < (iter/4); b++)
+			loc_procbuf[ir][b] = TPackedScore::pack_full(pvScore + b*8, pvScore + b*8 + 4);
+		if constexpr((iter % 4) != 0) {
+			const TIdxSize b = iter / 4;
+			const uint8_t *pe0 = pvScore + b * 8;
+			loc_procbuf[ir][b] = TPackedScore::pack_remainder(pe0, pe0 + 4, iter % 4);
+		}
+	}
+
+	// Maximum score in final row
+	EEU8_TCScore lrmax = MIN_U8;
+
+	// H and E vectors for each j-step, packed two per element
+	TPackedEH bufEH[(iter+1)/2];
+
+	constexpr int last_step = iter - 1;
+	constexpr int last_elem = last_step / 2;
+	constexpr int last_slot = last_step % 2;
+
+	// Fill in the table as usual but instead of using the same gap-penalty
+	// vector for each iteration of the inner loop, load words out of a
+	// pre-calculated gap vector parallel to the query profile.  The pre-
+	// calculated gap vectors enforce the gap barrier constraint by making it
+	// infinitely costly to introduce a gap in barrier rows.
+
+        uint8_t *pbuf = pmat;
+
+	// For each character in the reference text
+	for(TIdxSize i = 0; i < rfd; i++) {
+		
+		// Fetch the appropriate query profile.  Note that elements of rf must
+		// be numbers, not masks.
+		const size_t ir = (size_t)std::countr_zero( uint8_t(rf[i]) );
+	
+		// scalar version of EEU8_alignOne()
+		{
+		  // Set all cells to low value
+		  uint8_t vf = 0;
+
+		  // in scalar mode, we always start high
+		  uint8_t vh = 0xff;
+
+#ifdef OMPGPU
+		  // Full unrolling allows bufEH to be mapped to the GPU register file
+		  // Only downsides for the CPUs, that have fewer registers
+#pragma omp unroll full
+#endif
+		  // E and H scores are kept in uint8_t, coming in pairs and packed into 4 bytes
+		  // However a single byte encodes 4 biasing pairs of every cell, hence doing 4 per loop
+		  // score_off is the logical index within the packed byte (0-3).
+		  for(TIdxSize b = 0; b < (iter/4); b++) {
+		    const TPackedScore full_score(loc_procbuf[ir][b]);
+		    bufEH[b*2].apply_step(full_score, 0, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		    pbuf+=3*VSize;
+		    bufEH[b*2].apply_step(full_score, 1, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		    pbuf+=3*VSize;
+		    bufEH[b*2+1].apply_step(full_score, 2, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		    pbuf+=3*VSize;
+		    bufEH[b*2+1].apply_step(full_score, 3, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		    pbuf+=3*VSize;
+		  }
+		  // Do remaining elements
+		  if constexpr((iter % 4) != 0) {
+		    const TIdxSize b = iter / 4;
+		    const TPackedScore full_score(loc_procbuf[ir][b]);
+		    bufEH[b*2].apply_step(full_score, 0, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		    pbuf+=3*VSize;
+		    if constexpr((iter % 4) >= 2) {
+		      bufEH[b*2].apply_step(full_score, 1, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		      pbuf+=3*VSize;
+		    }
+		    if constexpr((iter % 4) >= 3) {
+		      bufEH[b*2+1].apply_step(full_score, 2, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		      pbuf+=3*VSize;
+		    }
+		  }
+		}
+
+		// Note: we may not want to extract from the final row
+		//       EEU8_TCScore == uint8_t == uint8_t
+		EEU8_TCScore lr = bufEH[last_elem].get_H(last_slot);
+		if(lr > lrmax) {
+			lrmax = lr;
+		}
+	}
+
+	return lrmax;
+}
+
 #ifndef SWSSE_INLINE_ONLY
 /**
  * Align read 'rd' to reference using read & reference information given

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -1270,11 +1270,11 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRM11Scalar(const uint8_t profbuf[],
 
 /* 
  * Using the same algorithm as EEU8_alignNucleotidesLRM11Scalar, 
- * but returning pmat filled-in EEU8_alignNucleotides
+ * but returning pmat filled-in like EEU8_alignNucleotides does.
  * That said, it uses a different output layout, to improve write coalescing
  * 
  * The original uses a contiguous for each function invocation,
- *   with each element in pmat really being a (E,F,H,T) tuple, which are consecutive
+ *   with each element in pmat really being a (E,F,H,TMP) tuple, which are consecutive
  *   (see SSEMatrix in aligner_swsse.h)
  *
  * This variant uses a  stripped approach, with each function invocation
@@ -1282,7 +1282,11 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRM11Scalar(const uint8_t profbuf[],
  *    Conceptually, it is the same as having VSize function invocations writing vector<VSize> elements.
  *    (Which is effectively what happens on a GPU, due to SIMT execution)
  *
- *    Moreover, we are only saving E, F and H (T was an internal work area)
+ * The caller is expected to use a loop similar to this:
+ *    for (int i=0; i<VSize; i++) EEU8_alignNucleotidesM11Scalar(..., pmat+i, ...)
+ *
+ * Note that TMP elements are never written into, as they do not have a well defined semantics.
+ * (were used as a scratch area internally to EEU8_alignNucleotides)
  *
  * Also returns btnfilled.
  */
@@ -1493,8 +1497,6 @@ inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 	// calculated gap vectors enforce the gap barrier constraint by making it
 	// infinitely costly to introduce a gap in barrier rows.
 
-        uint8_t *pbuf = pmat;
-
 	// For each character in the reference text
 	for(TIdxSize i = 0; i < rfd; i++) {
 		
@@ -1510,6 +1512,8 @@ inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 		  // in scalar mode, we always start high
 		  uint8_t vh = 0xff;
 
+		  uint8_t *mypmat = pmat+(size_t(ROWSTRIDE*VSize)*iter*i);
+
 #ifdef OMPGPU
 		  // Full unrolling allows bufEH to be mapped to the GPU register file
 		  // Only downsides for the CPUs, that have fewer registers
@@ -1520,28 +1524,28 @@ inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 		  // score_off is the logical index within the packed byte (0-3).
 		  for(TIdxSize b = 0; b < (iter/4); b++) {
 		    const TPackedScore full_score(loc_procbuf[ir][b]);
-		    bufEH[b*2].apply_step(full_score, 0, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
-		    pbuf+=3*VSize;
-		    bufEH[b*2].apply_step(full_score, 1, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
-		    pbuf+=3*VSize;
-		    bufEH[b*2+1].apply_step(full_score, 2, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
-		    pbuf+=3*VSize;
-		    bufEH[b*2+1].apply_step(full_score, 3, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
-		    pbuf+=3*VSize;
+		    bufEH[b*2].apply_step(full_score, 0, mypmat, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		    mypmat+=ROWSTRIDE*VSize;
+		    bufEH[b*2].apply_step(full_score, 1, mypmat, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		    mypmat+=ROWSTRIDE*VSize;
+		    bufEH[b*2+1].apply_step(full_score, 2, mypmat, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		    mypmat+=ROWSTRIDE*VSize;
+		    bufEH[b*2+1].apply_step(full_score, 3, mypmat, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		    mypmat+=ROWSTRIDE*VSize;
 		  }
 		  // Do remaining elements
 		  if constexpr((iter % 4) != 0) {
 		    const TIdxSize b = iter / 4;
 		    const TPackedScore full_score(loc_procbuf[ir][b]);
-		    bufEH[b*2].apply_step(full_score, 0, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
-		    pbuf+=3*VSize;
+		    bufEH[b*2].apply_step(full_score, 0, mypmat, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		    mypmat+=ROWSTRIDE*VSize;
 		    if constexpr((iter % 4) >= 2) {
-		      bufEH[b*2].apply_step(full_score, 1, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
-		      pbuf+=3*VSize;
+		      bufEH[b*2].apply_step(full_score, 1, mypmat, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		      mypmat+=ROWSTRIDE*VSize;
 		    }
 		    if constexpr((iter % 4) >= 3) {
-		      bufEH[b*2+1].apply_step(full_score, 2, pbuf, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
-		      pbuf+=3*VSize;
+		      bufEH[b*2+1].apply_step(full_score, 2, mypmat, vf, vh, rdgapo, rdgape, rfgapo, rfgape);
+		      mypmat+=ROWSTRIDE*VSize;
 		    }
 		  }
 		}

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -1279,7 +1279,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 					const char   rf[], const TIdxSize rfd,
 					uint8_t pmat[],
 					const TAlScore minsc, const size_t nrow,
-					TIdxSize& btnfilled_,
+					DpBtCandidate btncand[], TIdxSize& btnfilled_,
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
         class TPackedScore {
 	private:
@@ -1537,7 +1537,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 		lrmax = std::max(lr,lrmax);
 		if (lr >= minlr) {
 			// Yes, this is legit
-			// TODO: Save also (i, lr)
+			btncand[btnfilled].init(nrow-1, i, lr);
 			btnfilled++;
 		}
 	}

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -1269,8 +1269,20 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRM11Scalar(const uint8_t profbuf[],
 }
 
 /* 
- * Like EEU8_alignNucleotidesLRM11Scalar, but actually saves E,F,H, too 
+ * Using the same algorithm as EEU8_alignNucleotidesLRM11Scalar, 
+ * but returning pmat filled-in EEU8_alignNucleotides
  * That said, it uses a different output layout, to improve write coalescing
+ * 
+ * The original uses a contiguous for each function invocation,
+ *   with each element in pmat really being a (E,F,H,T) tuple, which are consecutive
+ *   (see SSEMatrix in aligner_swsse.h)
+ *
+ * This variant uses a  stripped approach, with each function invocation
+ *    writing evey VSize-th element only (The caller is expected to provide a shifted pmat)
+ *    Conceptually, it is the same as having VSize function invocations writing vector<VSize> elements.
+ *    (Which is effectively what happens on a GPU, due to SIMT execution)
+ *
+ *    Moreover, we are only saving E, F and H (T was an internal work area)
  *
  * Also returns btnfilled.
  */
@@ -1377,7 +1389,8 @@ inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 			vf = subs_u8(vf, vs1); // veto some ref gap extensions
 
 			// save F
-			pmat[0] = vf;
+			// (SSEMatrixConsts::F==2)
+			pmat[SSEMatrixConsts::F*VSize] = vf;
 
 			// Factor in query profile (matches and mismatches)
 			vh = subs_u8(vh, vs0);
@@ -1387,7 +1400,8 @@ inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 			vh = std::max(vh, vf);
 
 			// save H
-			pmat[VSize] = vh;
+			// (SSEMatrixConsts::H==1)
+			pmat[SSEMatrixConsts::H*VSize] = vh;
 
 			// Save the new vH values
 			uint8_t vtmp = vh;
@@ -1399,7 +1413,8 @@ inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 			ve = std::max(ve, vh);
 
 			// save E
-			pmat[2*VSize] = ve;
+			// (SSEMatrixConsts::E==0)
+			pmat[SSEMatrixConsts::E*VSize] = ve;
 
 			// Save E and H values for next i round
 			set_bytes(i, ve, vtmp);

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -1019,9 +1019,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRScalar(const uint8_t profbuf[],
 		//       EEU8_TCScore == uint8_t == uint8_t
 		// Was: EEU8_TCScore lr = bufEH2[iter - 1].get_H();
 		EEU8_TCScore lr = ((iter%2)!=0) ? bufEH[iter/2].get_H_even() : bufEH[(iter-1)/2].get_H_odd();
-		if(lr > lrmax) {
-			lrmax = lr;
-		}
+		lrmax = std::max(lr,lrmax);
 	}
 
 	return lrmax;
@@ -1264,9 +1262,7 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRM11Scalar(const uint8_t profbuf[],
 		// Note: we may not want to extract from the final row
 		//       EEU8_TCScore == uint8_t == uint8_t
 		EEU8_TCScore lr = bufEH[last_elem].get_H(last_slot);
-		if(lr > lrmax) {
-			lrmax = lr;
-		}
+		lrmax = std::max(lr,lrmax);
 	}
 
 	return lrmax;
@@ -1275,12 +1271,15 @@ inline EEU8_TCScore EEU8_alignNucleotidesLRM11Scalar(const uint8_t profbuf[],
 /* 
  * Like EEU8_alignNucleotidesLRM11Scalar, but actually saves E,F,H, too 
  * That said, it uses a different output layout, to improve write coalescing
+ *
+ * Also returns btnfilled.
  */
 template<typename TIdxSize=uint16_t, uint16_t MAX_ITER=151, uint16_t MAX_RB=5, uint32_t VSize=64>
 inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 					const char   rf[], const TIdxSize rfd,
 					uint8_t pmat[],
-					const size_t nrow,
+					const TAlScore minsc, const size_t nrow,
+					TIdxSize& btnfilled_,
 					const int8_t refGapOpen, const int8_t refGapExtend, const int8_t readGapOpen, const int8_t readGapExtend) {
         class TPackedScore {
 	private:
@@ -1449,8 +1448,22 @@ inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 		}
 	}
 
+	// sc := lr - 0xff
+	// minlr = minsc + 0xff
+	// Make it fit inside uint8_t
+	const EEU8_TCScore minlr = 
+		(minsc<=(-255)) 
+		? 0                 // underflow
+		: ((minsc>0) 
+			? 0xff      // overflow
+			: (minsc + 0xff)
+		  );
+
 	// Maximum score in final row
 	EEU8_TCScore lrmax = MIN_U8;
+
+	// keep a local copy
+	TIdxSize btnfilled = 0;
 
 	// H and E vectors for each j-step, packed two per element
 	TPackedEH bufEH[(iter+1)/2];
@@ -1521,11 +1534,15 @@ inline EEU8_TCScore EEU8_alignNucleotidesM11Scalar(const uint8_t profbuf[],
 		// Note: we may not want to extract from the final row
 		//       EEU8_TCScore == uint8_t == uint8_t
 		EEU8_TCScore lr = bufEH[last_elem].get_H(last_slot);
-		if(lr > lrmax) {
-			lrmax = lr;
+		lrmax = std::max(lr,lrmax);
+		if (lr >= minlr) {
+			// Yes, this is legit
+			// TODO: Save also (i, lr)
+			btnfilled++;
 		}
 	}
 
+	btnfilled_ = btnfilled;  // pass it out
 	return lrmax;
 }
 

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -507,7 +507,7 @@ void align_ee8(const int npar, const int nels,
 	// output is aligned on the 64-wide vector
 	int b64 = i/64;
 	int v64 = i%64;
-	TMatBuf       *my_mat = mat+b64*64*size_t(MAX_MAT_EL) + v64;
+	TMatBuf       *my_mat = mat+b64*64*3*iter*rfd + v64;
 #endif
 	DpBtCandidate *my_btncand = btncand+i*size_t(MAX_RF_EL);
 #endif

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -352,7 +352,7 @@ int align_ee8_one(const int el, // for debuggging purpose
 	const EEU8_TCScore lrmax = EEU8_alignNucleotidesM11Scalar<uint16_t,151>(profbuf, rf, rfd,
 					mat,
 					minsc, nrow,
-					btnfilled,
+					btncand, btnfilled,
 					gaps[0],gaps[1],gaps[2],gaps[3]);
 
 #endif

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -508,7 +508,7 @@ void align_ee8(const int npar, const int nels,
 	// output is aligned on the 64-wide vector
 	int b64 = i/64;
 	int v64 = i%64;
-	TMatBuf       *my_mat = mat+b64*64*3*iter*rfd + v64;
+	TMatBuf       *my_mat = mat+b64*64*ROWSTRIDE*iter*rfd + v64;
 #endif
 	DpBtCandidate *my_btncand = btncand+i*size_t(MAX_RF_EL);
 #endif

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -595,6 +595,7 @@ int load_and_align_ee8(const int npar, int nels) {
 #endif
    auto t2b = std::chrono::high_resolution_clock::now();
    // we filtered the eleemnts, we can now assume they are homogeneous
+   fprintf(stderr, "INFO: #iter = %i #rfd = %i #row = %i #minsc = %i\n",int(iter[0]),int(rfd[0]),int(nrow[0]),int(minsc[0]));
    align_ee8(npar, nels,
 		nrow[0], iter[0], colstride[0], lastWordIdx[0],minsc[0],rfd[0], // homogeneous
 		gaps, // 4 elements, so passing by pointer, but still homogeneous

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -351,7 +351,8 @@ int align_ee8_one(const int el, // for debuggging purpose
 #else
 	const EEU8_TCScore lrmax = EEU8_alignNucleotidesM11Scalar<uint16_t,151>(profbuf, rf, rfd,
 					mat,
-					nrow,
+					minsc, nrow,
+					btnfilled,
 					gaps[0],gaps[1],gaps[2],gaps[3]);
 
 #endif
@@ -381,7 +382,7 @@ int align_ee8_one(const int el, // for debuggging purpose
 	int nerrs = 0;
 	computed_lrmax = lrmax;
 	if (int(ref_lrmax) != int(lrmax)) nerrs++;
-#if  !(defined(PRE_LR_SCALAR)||defined(PRE_M11_SCALAR))
+#if  !defined(PRE_LR_SCALAR)
 	if (int(ref_btnfilled) != int(btnfilled)) nerrs++;
 #else
 	TAlScore sc = (TAlScore)(lrmax - 0xff);

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -341,12 +341,21 @@ int align_ee8_one(const int el, // for debuggging purpose
                 const int32_t ref_btnfilled) {
 #ifndef PRE_LR_SCALAR
 	uint16_t btnfilled = 0;
+#ifndef PRE_M11_SCALAR
 	const EEU8_TCScore lrmax = EEU8_alignNucleotides<uint16_t>(profbuf, rf, rfd,
 					mat,
                                         iter, colstride, lastWordIdx,
 					minsc, nrow,
 					btncand, btnfilled,
 					gaps[0],gaps[1],gaps[2],gaps[3]);
+#else
+	const EEU8_TCScore lrmax = EEU8_alignNucleotidesM11Scalar<uint16_t,151>(profbuf, rf, rfd,
+					mat,
+					nrow,
+					gaps[0],gaps[1],gaps[2],gaps[3]);
+
+#endif
+
 #else
 
 #if 0
@@ -372,7 +381,7 @@ int align_ee8_one(const int el, // for debuggging purpose
 	int nerrs = 0;
 	computed_lrmax = lrmax;
 	if (int(ref_lrmax) != int(lrmax)) nerrs++;
-#ifndef PRE_LR_SCALAR
+#if  !(defined(PRE_LR_SCALAR)||defined(PRE_M11_SCALAR))
 	if (int(ref_btnfilled) != int(btnfilled)) nerrs++;
 #else
 	TAlScore sc = (TAlScore)(lrmax - 0xff);
@@ -492,7 +501,14 @@ void align_ee8(const int npar, const int nels,
       for (int i=p*elp_pp; i<iend; i++) {
 #if defined(OMPGPU) && !defined(PRE_LR_SCALAR)
 	// the loop is parallel, so we must use a different buffer for each element
+#ifndef PRE_M11_SCALAR
 	TMatBuf       *my_mat = mat+i*size_t(MAX_MAT_EL);
+#else
+	// output is aligned on the 64-wide vector
+	int b64 = i/64;
+	int v64 = i%64;
+	TMatBuf       *my_mat = mat+b64*64*size_t(MAX_MAT_EL) + v64;
+#endif
 	DpBtCandidate *my_btncand = btncand+i*size_t(MAX_RF_EL);
 #endif
          nerrs+= align_ee8_one(i,
@@ -527,19 +543,6 @@ int load_and_align_ee8(const int npar, int nels) {
    int32_t *ref_lrmax = new int32_t[nels];
    int32_t *ref_btnfilled = new int32_t[nels];
    SSERegI *profbuf = new (std::align_val_t(1024))  SSERegI[size_t(nels)*MAX_PB_EL];
-#if defined(PRE_LR_SCALAR)
-   // no mat or btncand, just pass NULLs around 
-   TMatBuf        *mat = nullptr;
-   DpBtCandidate *btncand = nullptr;
-#elif !defined(OMPGPU)
-   // one per thread is enough on the CPU
-   TMatBuf       *mat = new  (std::align_val_t(1024))  TMatBuf[size_t(npar)*MAX_MAT_EL];
-   DpBtCandidate *btncand = new  (std::align_val_t(1024)) DpBtCandidate[size_t(MAX_RF_EL)*npar];
-#else
-   // no shortcuts on the GPU
-   TMatBuf       *mat = new  (std::align_val_t(1024)) TMatBuf[size_t(nels)*MAX_MAT_EL];
-   DpBtCandidate *btncand = new  (std::align_val_t(1024)) DpBtCandidate[size_t(MAX_RF_EL)*nels];
-#endif
    char    *rf = new  (std::align_val_t(1024)) char[size_t(MAX_RF_EL)*nels];
    size_t  *nrow = new size_t[nels];
    size_t  *iter = new size_t[nels];
@@ -576,6 +579,19 @@ int load_and_align_ee8(const int npar, int nels) {
 #endif
    auto t2a = std::chrono::high_resolution_clock::now();
    for (int i=0; i<nels; i++) computed_lrmax[i] = -1; // invalidate
+#if defined(PRE_LR_SCALAR)
+   // no mat or btncand, just pass NULLs around 
+   TMatBuf        *mat = nullptr;
+   DpBtCandidate *btncand = nullptr;
+#elif !defined(OMPGPU)
+   // one per thread is enough on the CPU
+   TMatBuf       *mat = new  (std::align_val_t(1024))  TMatBuf[size_t(npar)*MAX_MAT_EL];
+   DpBtCandidate *btncand = new  (std::align_val_t(1024)) DpBtCandidate[size_t(MAX_RF_EL)*npar];
+#else
+   // no shortcuts on the GPU
+   TMatBuf       *mat = new  (std::align_val_t(1024)) TMatBuf[size_t(nels)*MAX_MAT_EL];
+   DpBtCandidate *btncand = new  (std::align_val_t(1024)) DpBtCandidate[size_t(MAX_RF_EL)*nels];
+#endif
    auto t2b = std::chrono::high_resolution_clock::now();
    // we filtered the eleemnts, we can now assume they are homogeneous
    align_ee8(npar, nels,

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -22,7 +22,7 @@ typedef SSERegI TMatBuf;
 typedef uint8_t TMatBuf __attribute__((ext_vector_type(VECT_SIZE)));
 #endif
 
-int load_data(int nels,
+int load_data(int nels, int skip_blocks,
 		size_t nrow[],
 		size_t iter[],
 		size_t colstride[],
@@ -40,8 +40,10 @@ int load_data(int nels,
       fprintf(stderr, "Could not open %s\n",fname);
       return 2;
    }
-   
-   for (int i=0; i<nels; i++) {
+ 
+   for (int b=0; b<=skip_blocks; b++) {
+    // read all elements, keep only the last pass
+    for (int i=0; i<nels; i++) {
       uint32_t magic = 0;
       uint32_t isize = 0;
       uint32_t cnt = 9999999;
@@ -52,7 +54,7 @@ int load_data(int nels,
       tread(&isize,sizeof(uint32_t), 1, file);
       if (isize != sizeof(SSERegI)) {fprintf(stderr, "Wrong isize\n"); return 4;}
       tread(&cnt,sizeof(uint32_t), 1, file);
-      if (cnt != i) {fprintf(stderr, "Wrong cnt\n"); return 4;}
+      if (cnt != (i+b*nels)) {fprintf(stderr, "Wrong cnt\n"); return 4;}
       tread(nrow+i,sizeof(size_t), 1, file);
       tread(iter+i,sizeof(size_t), 1, file);
       tread(colstride+i,sizeof(size_t), 1, file);
@@ -67,13 +69,14 @@ int load_data(int nels,
       if (rfd[i]>MAX_RF_EL) {fprintf(stderr, "RF size too big %i\n", int(rfd[i])); return 4;}
       tread(rf+(i*size_t(MAX_RF_EL)), sizeof(char), rfd[i], file);
       tread(gaps+i*4, sizeof(int8_t), 4, file);
+    }
    }
 
    fclose(file);
    return 0;
 }
 
-int load_results(int nels,
+int load_results(int nels, int skip_blocks,
 		int32_t lrmax[],
 		int32_t btnfilled[]) {
    char fname[256];
@@ -84,12 +87,15 @@ int load_results(int nels,
       return 2;
    }
    
-   for (int i=0; i<nels; i++) {
+   for (int b=0; b<=skip_blocks; b++) {
+    // read all elements, keep only the last pass
+    for (int i=0; i<nels; i++) {
       uint32_t cnt = 9999999;
       tread(&cnt,sizeof(uint32_t), 1, file);
-      if (cnt != i) {fprintf(stderr, "Wrong cnt\n"); return 4;}
+      if (cnt != (i+b*nels)) {fprintf(stderr, "Wrong cnt\n"); return 4;}
       tread(lrmax+i,sizeof(int32_t), 1, file);
       tread(btnfilled+i,sizeof(int32_t), 1, file);
+    }
    }
 
    fclose(file);
@@ -559,7 +565,7 @@ void align_ee8(const int npar, const int nels,
 
 }
 
-int load_and_align_ee8(const int npar, int nels, bool pass2_only) {
+int load_and_align_ee8(const int npar, int nels, bool pass2_only, int skip_blocks) {
    int32_t *computed_lrmax = new int32_t[nels];
    int32_t *ref_lrmax = new int32_t[nels];
    int32_t *ref_btnfilled = new int32_t[nels];
@@ -575,10 +581,10 @@ int load_and_align_ee8(const int npar, int nels, bool pass2_only) {
 
    auto t1 = std::chrono::high_resolution_clock::now();
    // test tool, don't worry about perfect cleanup
-   if (load_data(nels,
+   if (load_data(nels, skip_blocks,
 		nrow, iter, colstride, lastWordIdx,minsc,rfd,
 		profbuf,rf,gaps) !=0 ) return 1;
-   if (load_results(nels,
+   if (load_results(nels, skip_blocks,
 		ref_lrmax, ref_btnfilled) !=0 ) return 1;
    nels = filter(nels,
                 nrow, iter, colstride, lastWordIdx, minsc,
@@ -703,14 +709,18 @@ int load_and_align_ee8(const int npar, int nels, bool pass2_only) {
 
 int main(int argv, const char* argc[]) {
    if (argv<3) {
-     fprintf(stderr, "Usage: test_align_ee8 <npar> <nels> [<pass2_only>]\n");
+     fprintf(stderr, "Usage: test_align_ee8 <npar> <nels> [<pass2_only>] [<skip_blocks>]\n");
      return 1;
    }
    int npar = atoi(argc[1]);
    int nels = atoi(argc[2]);
    int pass2_only = 0;
+   int skip_blocks = 0;
    if (argv>3) {
      pass2_only = atoi(argc[3]);
+   }
+   if (argv>4) {
+     skip_blocks = atoi(argc[4]);
    }
 
 #ifdef USE_BUILTIN_SUB_SAT
@@ -735,5 +745,5 @@ int main(int argv, const char* argc[]) {
      }
    }
 #endif
-   return load_and_align_ee8(npar,nels,pass2_only!=0);
+   return load_and_align_ee8(npar,nels,pass2_only!=0i,skip_blocks);
 }

--- a/devsupport/align_ee8.cpp
+++ b/devsupport/align_ee8.cpp
@@ -138,7 +138,8 @@ int filter(int nels,
 		char    rf[],
 		uint8_t gaps[],
 		int32_t lrmax[],
-		int32_t btnfilled[]
+		int32_t btnfilled[],
+		const bool pass2_only
 		) {
    uint32_t *gaps4 = (uint32_t*)gaps;
    bool is_first = true;
@@ -149,6 +150,7 @@ int filter(int nels,
    size_t rfd_first;
    uint32_t gaps_first;
 
+   int filter_pass2_n = 0;
    int filter_iter_n = 0;
    int filter_nrow_n = 0;
    int filter_colstride_n = 0;
@@ -159,6 +161,24 @@ int filter(int nels,
    int good_els = nels;
    int i = 0;
    while (i<good_els) {
+      if (pass2_only) {
+	const int32_t minlr = 
+		(minsc[i]<=(-255)) 
+		? 0                 // underflow
+		: ((minsc[i]>0) 
+			? 0xff      // overflow
+			: (minsc[i] + 0xff)
+		  );
+        if (lrmax[i]<minlr) {
+    	   // this one does not need a 2nd pass
+	   swap_data(i, good_els-1,
+                nrow, iter, colstride, lastWordIdx, minsc,
+                rfd, profbuf, rf, gaps, lrmax, btnfilled);
+	   good_els--;
+	   filter_pass2_n++;
+	   continue;
+	}
+      }
       if (iter[i]!=((151+(NBYTES_PER_REG-1))/NBYTES_PER_REG)) {
 	// keep the most relevant one
 	swap_data(i, good_els-1,
@@ -236,8 +256,8 @@ int filter(int nels,
    }
 
    fprintf(stderr, "INFO: Filtered from %i down to %i (%3.2f%%)\n",int(nels), int(good_els),100.0*good_els/nels);
-   fprintf(stderr, "INFO: Filter iter: %i rfd: %i gaps: %i nrow: %i colstride: %i lastWordIdx: %i minsc: %i\n",
-		   filter_iter_n,filter_rfd_n,filter_gaps_n,filter_nrow_n,filter_colstride_n,filter_lastWordIdx_n,filter_minsc_n);
+   fprintf(stderr, "INFO: Filter pass2: %i iter: %i rfd: %i gaps: %i nrow: %i colstride: %i lastWordIdx: %i minsc: %i\n",
+		   filter_pass2_n, filter_iter_n,filter_rfd_n,filter_gaps_n,filter_nrow_n,filter_colstride_n,filter_lastWordIdx_n,filter_minsc_n);
    return good_els;
 }
 
@@ -539,7 +559,7 @@ void align_ee8(const int npar, const int nels,
 
 }
 
-int load_and_align_ee8(const int npar, int nels) {
+int load_and_align_ee8(const int npar, int nels, bool pass2_only) {
    int32_t *computed_lrmax = new int32_t[nels];
    int32_t *ref_lrmax = new int32_t[nels];
    int32_t *ref_btnfilled = new int32_t[nels];
@@ -562,7 +582,8 @@ int load_and_align_ee8(const int npar, int nels) {
 		ref_lrmax, ref_btnfilled) !=0 ) return 1;
    nels = filter(nels,
                 nrow, iter, colstride, lastWordIdx, minsc,
-                rfd, profbuf, rf, gaps, ref_lrmax, ref_btnfilled);
+                rfd, profbuf, rf, gaps, ref_lrmax, ref_btnfilled,
+		pass2_only);
 #ifdef CPUVECT
    // TODO: Fix the code to support non-multiple numbers
    if ((nels%VECT_SIZE)!=0) {
@@ -681,12 +702,16 @@ int load_and_align_ee8(const int npar, int nels) {
 
 
 int main(int argv, const char* argc[]) {
-   if (argv<2) {
-     fprintf(stderr, "Usage: test_align_ee8 <npar> <nels>\n");
+   if (argv<3) {
+     fprintf(stderr, "Usage: test_align_ee8 <npar> <nels> [<pass2_only>]\n");
      return 1;
    }
    int npar = atoi(argc[1]);
    int nels = atoi(argc[2]);
+   int pass2_only = 0;
+   if (argv>3) {
+     pass2_only = atoi(argc[3]);
+   }
 
 #ifdef USE_BUILTIN_SUB_SAT
    {
@@ -710,5 +735,5 @@ int main(int argv, const char* argc[]) {
      }
    }
 #endif
-   return load_and_align_ee8(npar,nels);
+   return load_and_align_ee8(npar,nels,pass2_only!=0);
 }


### PR DESCRIPTION
EEU8_alignNucleotidesM11Scalar uses the same algorithm as EEU8_alignNucleotidesLRM11Scalar, 
but returns pmat filled-in like EEU8_alignNucleotides does.

Optimized for GPU compute, with stripped pmat semantics.