### PR TITLE
Lrfilter Step, disaggregates extendSeeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,14 @@ CXX := amdclang++
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DCPUVECT -DUSE_BUILTIN_SUB_SAT -march=native
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
-
+CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
 
 #
 # GPU-enabled
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm  -Rpass-analysis=kernel-resource-usage
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
-CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_M11_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
 
 # Enable HIP. Use CXX=amdclang++ or CXX=hipcc 
 # Warning with hybrid OPENMP Compilations

--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,14 @@ CXX := amdclang++
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DCPUVECT -DUSE_BUILTIN_SUB_SAT -march=native
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR
-CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
+#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_AVX2
+
 
 #
 # GPU-enabled
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm  -Rpass-analysis=kernel-resource-usage
 #CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DPBMASK -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
-#CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_M11_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
+CXXFLAGS += -std=c++20 -DFORCE_ALL_OMP -mavx2 -faligned-new -DPRE_LR_SCALAR -DSSE_SCALAR -DNO_CHECK_PRINT -DOMPGPU -fopenmp-offload-mandatory --offload-arch=native -fopenmp-force-usm -Rpass-analysis=kernel-resource-usage
 
 # Enable HIP. Use CXX=amdclang++ or CXX=hipcc 
 # Warning with hybrid OPENMP Compilations

--- a/aligner_sw.h
+++ b/aligner_sw.h
@@ -66,6 +66,9 @@
 
 #define INLINE_CUPS
 
+// Struct used for better contigous memory in batching, necessary for lrfilter flag speedup
+struct ExtendCandidate;
+
 #include <stdint.h>
 #include <iostream>
 #include <limits>
@@ -288,6 +291,20 @@ public:
 	 */
 	bool align(TAlScore& best);
 	bool alignEnd2EndSseU8(TAlScore& best);
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+	// Runs the LRM11Scalar, which aligns nucleotides but only gets max score
+ // Low memory usage & large batching causes significant speedup
+	// Returns true if the candidate *may* align (score >= minsc), false to skip.
+	// Since often most candidates do not pass, this step is often worth doing
+ // Needs the the current initRef+initRead state, after initRef & buildQueryProfileEnd2EndSseU8.
+	bool filterLRM11(TAlScore minsc);
+
+	// After initRead+initRef, snapshot the query profile and decoded reference
+	// into cand's embedded arrays so the offload kernel needs only the struct.
+ // Although redundant, the contigous memory performs better on the offload
+	void fillCandBuffers(ExtendCandidate& cand);
+
+#endif
 #ifdef ENABLE_I16
 	bool alignEnd2EndSseI16(TAlScore& best);
 #endif

--- a/aligner_sw_driver.cpp
+++ b/aligner_sw_driver.cpp
@@ -43,6 +43,8 @@
  */
 
 #include <iostream>
+#include <atomic>
+#include <chrono>
 #include "aligner_cache.h"
 #include "aligner_sw_driver.h"
 #include "pe.h"
@@ -53,6 +55,61 @@
 // -- --
 
 using namespace std;
+
+static std::atomic<uint64_t> g_ns_initRef{0};
+static std::atomic<uint64_t> g_ns_align{0};
+static std::atomic<uint64_t> g_ns_backtrace{0};
+static std::atomic<uint64_t> g_n_initRef{0};
+static std::atomic<uint64_t> g_n_align{0};
+static std::atomic<uint64_t> g_n_backtrace{0};
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+static std::atomic<uint64_t> g_ns_lrfilter_initRef{0};
+static std::atomic<uint64_t> g_n_lrfilter_initRef{0};
+static std::atomic<uint64_t> g_ns_lrfilter{0};
+static std::atomic<uint64_t> g_n_lrfilter_pass{0};
+static std::atomic<uint64_t> g_n_lrfilter_total{0};
+#endif
+
+__attribute__((destructor))
+static void print_extend_timers() {
+	const uint64_t n_initRef   = g_n_initRef.load();
+	const uint64_t n_align     = g_n_align.load();
+	const uint64_t n_backtrace = g_n_backtrace.load();
+	const double ns_initRef   = (double)g_ns_initRef.load();
+	const double ns_align     = (double)g_ns_align.load();
+	const double ns_backtrace = (double)g_ns_backtrace.load();
+	fprintf(stderr, "PROFILE (accumulated CPU-ns across all threads, divide by thread count for wall time)\n");
+	fprintf(stderr, "  initRef:   %12.3f s total  %8.0f ns/call  (%lu calls)\n",
+		ns_initRef * 1e-9,
+		n_initRef   ? ns_initRef   / n_initRef   : 0.0,
+		(unsigned long)n_initRef);
+	fprintf(stderr, "  align:     %12.3f s total  %8.0f ns/call  (%lu calls)\n",
+		ns_align * 1e-9,
+		n_align     ? ns_align     / n_align     : 0.0,
+		(unsigned long)n_align);
+	fprintf(stderr, "  backtrace: %12.3f s total  %8.0f ns/call  (%lu calls)\n",
+		ns_backtrace * 1e-9,
+		n_backtrace ? ns_backtrace / n_backtrace : 0.0,
+		(unsigned long)n_backtrace);
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+	const uint64_t n_lrfilter_initRef = g_n_lrfilter_initRef.load();
+	const uint64_t n_lrfilter_pass    = g_n_lrfilter_pass.load();
+	const uint64_t n_lrfilter_total   = g_n_lrfilter_total.load();
+	const double ns_lrfilter_initRef  = (double)g_ns_lrfilter_initRef.load();
+	const double ns_lrfilter          = (double)g_ns_lrfilter.load();
+	fprintf(stderr, "  lrfilter initRef: %9.3f s total  %8.0f ns/call  (%lu calls)\n",
+		ns_lrfilter_initRef * 1e-9,
+		n_lrfilter_initRef ? ns_lrfilter_initRef / n_lrfilter_initRef : 0.0,
+		(unsigned long)n_lrfilter_initRef);
+	fprintf(stderr, "  lrfilter dp:      %9.3f s total  %8.0f ns/call  (%lu passed, %lu withheld / %lu total, %.1f%% pass rate)\n",
+		ns_lrfilter * 1e-9,
+		n_lrfilter_total ? ns_lrfilter / n_lrfilter_total : 0.0,
+		(unsigned long)n_lrfilter_pass,
+		(unsigned long)(n_lrfilter_total - n_lrfilter_pass),
+		(unsigned long)n_lrfilter_total,
+		n_lrfilter_total ? 100.0 * n_lrfilter_pass / n_lrfilter_total : 0.0);
+#endif
+}
 
 /**
  * Given seed results, set up all of our state for resolving and keeping
@@ -468,6 +525,296 @@ int SwDriver::extendSeeds(
 	assert_eq(neltLeft,0);
 
 	// Short-circuited because a limit, e.g. -k, -m or -M, was exceeded
+	return EXTEND_EXHAUSTED_CANDIDATES;
+}
+
+/*
+ * BWT walk -> collect DP candidates
+ * Ran before running alignment. This looks through BWT and gets the best matches via BWT
+ * then calls adds them to a list before running alignment
+ * (Most is just the first part of extendSeeds() )
+ */
+int SwDriver::extendSeedsCollect(
+	const Ebwt& ebwtFw,
+	const BitPairReference& ref,
+	SwAligner& swa,
+	const Scoring& sc,
+	const int seedmms,
+	const int seedlen,
+	const int seedival,
+	const TAlScore minsc,
+	const int nceil,
+	const size_t maxhalf,
+	PerReadMetrics& prm,
+	EList<ExtendCandidate>& cands
+	)
+{
+	cands.clear();
+
+	const size_t rows    = swa.dpRows();
+	const size_t rdlen   = rows;
+
+	assert_geq(nceil, 0);
+	assert_leq((size_t)nceil, rdlen);
+
+	TAlScore perfectScore = sc.perfectScore(rdlen);
+	if(minsc == perfectScore) {
+		fprintf(stderr, "Warning, internal logical: Found perfect score in extendSeedsCollect\n");
+		return EXTEND_PERFECT_SCORE;
+	}
+	const int readGaps = sc.maxReadGaps(minsc, rdlen);
+	const int refGaps  = sc.maxRefGaps(minsc, rdlen);
+
+	DynProgFramer dpframe(!reportOverhangs);
+	const uint32_t sp_size = satpos_.size();
+
+	for(uint32_t i = 0; i < sp_size; i++) {
+		auto &gws = gws_[0];
+
+		const SATupleAndPos& satpos = satpos_[i];
+		const size_t sat_size  = satpos.sat.size();
+		const bool fw          = satpos.pos.fw;
+		uint32_t rdoff         = satpos.pos.rdoff;
+		uint32_t seedhitlen    = satpos.pos.seedlen;
+
+		if(!fw) {
+			rdoff = (uint32_t)(rdlen - rdoff - seedhitlen);
+		}
+
+		{
+			SARangeWithOffs<TSlice> sa(
+				satpos.sat.topf, satpos.sat.key.len,
+				satpos.sat.offs, satpos.sat.fmap);
+			gws.reset();
+			gws.init(ebwtFw, ref, sa);
+			assert(gws.initialized());
+		}
+
+		for(uint32_t elt = 0; elt < sat_size; elt++) {
+			assert(!gws.done());
+			prm.nExIters++;
+			WalkResult wr;
+			SARangeWithOffs<TSlice> sa(
+				satpos.sat.topf, satpos.sat.key.len,
+				satpos.sat.offs, satpos.sat.fmap);
+			gws.advanceElement((TIndexOffU)elt, ebwtFw, ref, sa, gwstate_, wr, prm);
+			assert_neq(OFF_MASK, wr.toff);
+
+			TIndexOffU tidx = 0, toff = 0, tlen = 0;
+			bool straddled = false;
+			ebwtFw.joinedToTextOff(wr.elt.len, wr.toff, tidx, toff, tlen,
+			                       false, straddled);
+
+			int64_t refoff = (int64_t)toff - rdoff;
+			Coord refcoord(tidx, refoff, fw);
+			if(seenDiags1_.locusPresent(refcoord)) {
+				prm.nRedundants++;
+				continue;
+			}
+
+			DPRect rect;
+			bool found = dpframe.frameSeedExtensionRect(
+				refoff, rows, tlen, readGaps, refGaps,
+				(size_t)nceil, maxhalf, rect);
+			assert(rect.repOk());
+			seenDiags1_.add(Interval(refcoord, 1));
+			if(!found) continue;
+
+			size_t nwindow = 0;
+			if((int64_t)toff >= rect.refl) {
+				nwindow = (size_t)(toff - rect.refl);
+			}
+
+			ExtendCandidate cand;
+			cand.fw       = fw;
+			cand.tidx     = tidx;
+			cand.toff     = toff;
+			cand.tlen     = tlen;
+			cand.refoff   = refoff;
+			cand.rect     = rect;
+			cand.nwindow  = nwindow;
+			cand.refcoord = refcoord;
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+			cand.lrm11_passed = true; // default: pass-through (set by kernel if lrm11_ready)
+			cand.lrm11_ready  = false;
+			if(rows == 151) {
+				size_t nsInLeftShift = 0;
+				bool ok = swa.initRef(
+					fw, tidx, rect, ref,
+					tlen, minsc, true, true,
+					nwindow, nsInLeftShift);
+				if(ok) {
+					swa.fillCandBuffers(cand);
+					cand.lrm11_ready = true;
+				}
+			}
+#endif
+			cands.push_back(cand);
+		}
+	}
+
+	return EXTEND_EXHAUSTED_CANDIDATES; // collect never fulfils policy itself
+}
+
+
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+/*
+ * An optional part to run when splitting up extendSeeds
+ * Since often most alignments do not reach the target score (minsc) we can first run
+ * just calculating the lrfilter and not the full pmat, then rerun in seperate step
+ */
+void SwDriver::extendSeedsLRFilter(
+	EList<ExtendCandidate>& cands,
+	const BitPairReference& ref,
+	SwAligner& swa,
+	const TAlScore minsc,
+	const bool enable8)
+{
+	for(size_t ci = 0; ci < cands.size(); ci++) {
+		ExtendCandidate& cand = cands[ci];
+		size_t nsInLeftShift = 0;
+		auto _t0 = std::chrono::high_resolution_clock::now();
+		bool initOk = swa.initRef(
+			cand.fw, cand.tidx, cand.rect, ref,
+			cand.tlen, minsc, enable8,
+			true,
+			cand.nwindow, nsInLeftShift);
+		g_ns_lrfilter_initRef += (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+			std::chrono::high_resolution_clock::now() - _t0).count();
+		g_n_lrfilter_initRef++;
+		if(!initOk) {
+			cand.lrm11_passed = false;
+			continue;
+		}
+		auto _t1 = std::chrono::high_resolution_clock::now();
+		cand.lrm11_passed = swa.filterLRM11(minsc);
+		g_ns_lrfilter += (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+			std::chrono::high_resolution_clock::now() - _t1).count();
+		g_n_lrfilter_total++;
+		if(cand.lrm11_passed) g_n_lrfilter_pass++;
+	}
+}
+#endif
+
+/*
+ * The alignment step of extendSeeds(), so much of the code is similar
+ * Calculates the full scoring alignments
+ *     Calculates the score of full alignment DP matrix + candidates,
+ *     which is just the behavior of alignNucleotides_*()
+ * And retrieves the backtrace of sequence of the top scorers
+ */
+int SwDriver::extendSeedsAlign(
+	EList<ExtendCandidate>& cands,
+	const BitPairReference& ref,
+	SwAligner& swa,
+	const Scoring& sc,
+	const int seedmms,
+	const int seedlen,
+	const int seedival,
+	const TAlScore minsc,
+	const bool enable8,
+	PerReadMetrics& prm,
+	AlnSinkWrap* msink,
+	bool reportImmediately,
+	bool& exhaustive)
+{
+	assert(!reportImmediately || msink != NULL);
+	assert(!reportImmediately || !msink->maxed());
+
+	for(size_t ci = 0; ci < cands.size(); ci++) {
+		ExtendCandidate& cand = cands[ci];
+
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+		if(!cand.lrm11_passed) continue;
+#endif
+
+		bool initOk;
+		{
+			auto _t0 = std::chrono::high_resolution_clock::now();
+			size_t nsInLeftShift = 0;
+			initOk = swa.initRef(
+				cand.fw, cand.tidx, cand.rect, ref,
+				cand.tlen, minsc, enable8,
+				true,  // seed extension (not mate finding)
+				cand.nwindow, nsInLeftShift);
+			g_n_initRef++;
+			g_ns_initRef += (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+				std::chrono::high_resolution_clock::now() - _t0).count();
+		}
+		if(!initOk)
+		{
+			prm.nExDpFails++;
+			prm.nDpFail++;
+			return EXTEND_EXCEEDED_HARD_LIMIT;
+		}
+
+		Interval refival(cand.tidx, 0, cand.fw, 0);
+		cand.rect.initIval(refival); // const_cast-safe: rect is our own copy
+		seenDiags1_.add(refival);
+
+		TAlScore bestCell = std::numeric_limits<TAlScore>::min();
+		bool found;
+		{
+			auto _t0 = std::chrono::high_resolution_clock::now();
+			found = swa.align(bestCell);
+			g_ns_align += (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+				std::chrono::high_resolution_clock::now() - _t0).count();
+			g_n_align++;
+		}
+		prm.nExDps++;
+		if(!found) {
+			prm.nExDpFails++;
+			prm.nDpFail++;
+			if(bestCell > std::numeric_limits<TAlScore>::min() &&
+			   bestCell > prm.bestLtMinscMate1) {
+				prm.bestLtMinscMate1 = bestCell;
+			}
+			continue;
+		}
+		prm.nExDpSuccs++;
+		prm.nDpLastSucc = prm.nExDps - 1;
+		if(prm.nDpFail > prm.nDpFailStreak) prm.nDpFailStreak = prm.nDpFail;
+		prm.nDpFail = 0;
+
+		while(true) {
+			resGap_.reset();
+			assert(resGap_.empty());
+			if(swa.done()) break;
+			{
+				auto _t0 = std::chrono::high_resolution_clock::now();
+				swa.nextAlignment(resGap_, minsc);
+				g_ns_backtrace += (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+					std::chrono::high_resolution_clock::now() - _t0).count();
+				g_n_backtrace++;
+			}
+			found = !resGap_.empty();
+			if(!found) break;
+
+			SwResult* res = &resGap_;
+			Interval refival2(cand.tidx, 0, cand.fw, cand.tlen);
+			assert_gt(res->alres.refExtent(), 0);
+			if(reportOverhangs &&
+			   !refival2.containsIgnoreOrient(res->alres.refival()))
+			{
+				res->alres.clipOutside(true, 0, cand.tlen);
+				if(res->alres.refExtent() == 0) continue;
+			}
+			if(!refival2.overlapsIgnoreOrient(res->alres.refival())) continue;
+			if(redAnchor_.overlap(res->alres)) continue;
+			redAnchor_.add(res->alres);
+			res->alres.setParams(seedmms, seedlen, seedival, minsc);
+
+			if(reportImmediately) {
+				assert(msink != NULL);
+				assert(res->repOk());
+				assert(!msink->maxed());
+				if(msink->report(0, &res->alres, NULL)) {
+					return EXTEND_POLICY_FULFILLED;
+				}
+			}
+		}
+	}
+
 	return EXTEND_EXHAUSTED_CANDIDATES;
 }
 

--- a/aligner_sw_driver.cpp
+++ b/aligner_sw_driver.cpp
@@ -43,8 +43,6 @@
  */
 
 #include <iostream>
-#include <atomic>
-#include <chrono>
 #include "aligner_cache.h"
 #include "aligner_sw_driver.h"
 #include "pe.h"
@@ -55,61 +53,6 @@
 // -- --
 
 using namespace std;
-
-static std::atomic<uint64_t> g_ns_initRef{0};
-static std::atomic<uint64_t> g_ns_align{0};
-static std::atomic<uint64_t> g_ns_backtrace{0};
-static std::atomic<uint64_t> g_n_initRef{0};
-static std::atomic<uint64_t> g_n_align{0};
-static std::atomic<uint64_t> g_n_backtrace{0};
-#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
-static std::atomic<uint64_t> g_ns_lrfilter_initRef{0};
-static std::atomic<uint64_t> g_n_lrfilter_initRef{0};
-static std::atomic<uint64_t> g_ns_lrfilter{0};
-static std::atomic<uint64_t> g_n_lrfilter_pass{0};
-static std::atomic<uint64_t> g_n_lrfilter_total{0};
-#endif
-
-__attribute__((destructor))
-static void print_extend_timers() {
-	const uint64_t n_initRef   = g_n_initRef.load();
-	const uint64_t n_align     = g_n_align.load();
-	const uint64_t n_backtrace = g_n_backtrace.load();
-	const double ns_initRef   = (double)g_ns_initRef.load();
-	const double ns_align     = (double)g_ns_align.load();
-	const double ns_backtrace = (double)g_ns_backtrace.load();
-	fprintf(stderr, "PROFILE (accumulated CPU-ns across all threads, divide by thread count for wall time)\n");
-	fprintf(stderr, "  initRef:   %12.3f s total  %8.0f ns/call  (%lu calls)\n",
-		ns_initRef * 1e-9,
-		n_initRef   ? ns_initRef   / n_initRef   : 0.0,
-		(unsigned long)n_initRef);
-	fprintf(stderr, "  align:     %12.3f s total  %8.0f ns/call  (%lu calls)\n",
-		ns_align * 1e-9,
-		n_align     ? ns_align     / n_align     : 0.0,
-		(unsigned long)n_align);
-	fprintf(stderr, "  backtrace: %12.3f s total  %8.0f ns/call  (%lu calls)\n",
-		ns_backtrace * 1e-9,
-		n_backtrace ? ns_backtrace / n_backtrace : 0.0,
-		(unsigned long)n_backtrace);
-#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
-	const uint64_t n_lrfilter_initRef = g_n_lrfilter_initRef.load();
-	const uint64_t n_lrfilter_pass    = g_n_lrfilter_pass.load();
-	const uint64_t n_lrfilter_total   = g_n_lrfilter_total.load();
-	const double ns_lrfilter_initRef  = (double)g_ns_lrfilter_initRef.load();
-	const double ns_lrfilter          = (double)g_ns_lrfilter.load();
-	fprintf(stderr, "  lrfilter initRef: %9.3f s total  %8.0f ns/call  (%lu calls)\n",
-		ns_lrfilter_initRef * 1e-9,
-		n_lrfilter_initRef ? ns_lrfilter_initRef / n_lrfilter_initRef : 0.0,
-		(unsigned long)n_lrfilter_initRef);
-	fprintf(stderr, "  lrfilter dp:      %9.3f s total  %8.0f ns/call  (%lu passed, %lu withheld / %lu total, %.1f%% pass rate)\n",
-		ns_lrfilter * 1e-9,
-		n_lrfilter_total ? ns_lrfilter / n_lrfilter_total : 0.0,
-		(unsigned long)n_lrfilter_pass,
-		(unsigned long)(n_lrfilter_total - n_lrfilter_pass),
-		(unsigned long)n_lrfilter_total,
-		n_lrfilter_total ? 100.0 * n_lrfilter_pass / n_lrfilter_total : 0.0);
-#endif
-}
 
 /**
  * Given seed results, set up all of our state for resolving and keeping
@@ -673,25 +616,16 @@ void SwDriver::extendSeedsLRFilter(
 	for(size_t ci = 0; ci < cands.size(); ci++) {
 		ExtendCandidate& cand = cands[ci];
 		size_t nsInLeftShift = 0;
-		auto _t0 = std::chrono::high_resolution_clock::now();
 		bool initOk = swa.initRef(
 			cand.fw, cand.tidx, cand.rect, ref,
 			cand.tlen, minsc, enable8,
 			true,
 			cand.nwindow, nsInLeftShift);
-		g_ns_lrfilter_initRef += (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
-			std::chrono::high_resolution_clock::now() - _t0).count();
-		g_n_lrfilter_initRef++;
 		if(!initOk) {
 			cand.lrm11_passed = false;
 			continue;
 		}
-		auto _t1 = std::chrono::high_resolution_clock::now();
 		cand.lrm11_passed = swa.filterLRM11(minsc);
-		g_ns_lrfilter += (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
-			std::chrono::high_resolution_clock::now() - _t1).count();
-		g_n_lrfilter_total++;
-		if(cand.lrm11_passed) g_n_lrfilter_pass++;
 	}
 }
 #endif
@@ -728,39 +662,29 @@ int SwDriver::extendSeedsAlign(
 		if(!cand.lrm11_passed) continue;
 #endif
 
-		bool initOk;
-		{
-			auto _t0 = std::chrono::high_resolution_clock::now();
-			size_t nsInLeftShift = 0;
-			initOk = swa.initRef(
-				cand.fw, cand.tidx, cand.rect, ref,
-				cand.tlen, minsc, enable8,
-				true,  // seed extension (not mate finding)
-				cand.nwindow, nsInLeftShift);
-			g_n_initRef++;
-			g_ns_initRef += (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
-				std::chrono::high_resolution_clock::now() - _t0).count();
-		}
-		if(!initOk)
-		{
+		size_t nsInLeftShift = 0;
+		bool initOk = swa.initRef(
+			cand.fw, cand.tidx, cand.rect, ref,
+			cand.tlen, minsc, enable8,
+			true,  // seed extension (not mate finding)
+			cand.nwindow, nsInLeftShift);
+		if(!initOk) {
+			// Something went terribly wrong (likely ncols too long)
+			// Just bail out
 			prm.nExDpFails++;
 			prm.nDpFail++;
 			return EXTEND_EXCEEDED_HARD_LIMIT;
 		}
-
+		// Because of how we framed the problem, we can say that we've
+		// exhaustively scored the seed diagonal as well as maxgaps
+		// diagonals on either side
 		Interval refival(cand.tidx, 0, cand.fw, 0);
 		cand.rect.initIval(refival); // const_cast-safe: rect is our own copy
 		seenDiags1_.add(refival);
-
+		// Now fill the dynamic programming matrix and return true iff
+		// there is at least one valid alignment
 		TAlScore bestCell = std::numeric_limits<TAlScore>::min();
-		bool found;
-		{
-			auto _t0 = std::chrono::high_resolution_clock::now();
-			found = swa.align(bestCell);
-			g_ns_align += (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
-				std::chrono::high_resolution_clock::now() - _t0).count();
-			g_n_align++;
-		}
+		bool found = swa.align(bestCell);
 		prm.nExDps++;
 		if(!found) {
 			prm.nExDpFails++;
@@ -769,24 +693,20 @@ int SwDriver::extendSeedsAlign(
 			   bestCell > prm.bestLtMinscMate1) {
 				prm.bestLtMinscMate1 = bestCell;
 			}
-			continue;
+			continue; // Look for more anchor alignments
+		} else {
+			prm.nExDpSuccs++;
+			prm.nDpLastSucc = prm.nExDps - 1;
+			if(prm.nDpFail > prm.nDpFailStreak) prm.nDpFailStreak = prm.nDpFail;
+			prm.nDpFail = 0;
 		}
-		prm.nExDpSuccs++;
-		prm.nDpLastSucc = prm.nExDps - 1;
-		if(prm.nDpFail > prm.nDpFailStreak) prm.nDpFailStreak = prm.nDpFail;
-		prm.nDpFail = 0;
 
 		while(true) {
+			assert(found);
 			resGap_.reset();
 			assert(resGap_.empty());
 			if(swa.done()) break;
-			{
-				auto _t0 = std::chrono::high_resolution_clock::now();
-				swa.nextAlignment(resGap_, minsc);
-				g_ns_backtrace += (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
-					std::chrono::high_resolution_clock::now() - _t0).count();
-				g_n_backtrace++;
-			}
+			swa.nextAlignment(resGap_, minsc);
 			found = !resGap_.empty();
 			if(!found) break;
 
@@ -799,16 +719,23 @@ int SwDriver::extendSeedsAlign(
 				res->alres.clipOutside(true, 0, cand.tlen);
 				if(res->alres.refExtent() == 0) continue;
 			}
+			// Did the alignment fall entirely outside the reference?
 			if(!refival2.overlapsIgnoreOrient(res->alres.refival())) continue;
+			// Is this alignment redundant with one we've seen previously?
 			if(redAnchor_.overlap(res->alres)) continue;
 			redAnchor_.add(res->alres);
+			// Annotate the AlnRes object with some key parameters
+			// that were used to obtain the alignment.
 			res->alres.setParams(seedmms, seedlen, seedival, minsc);
 
 			if(reportImmediately) {
 				assert(msink != NULL);
 				assert(res->repOk());
+				// Report an unpaired alignment
 				assert(!msink->maxed());
 				if(msink->report(0, &res->alres, NULL)) {
+					// Short-circuited because a limit, e.g. -k, -m or
+					// -M, was exceeded
 					return EXTEND_POLICY_FULFILLED;
 				}
 			}

--- a/aligner_sw_driver.h
+++ b/aligner_sw_driver.h
@@ -211,6 +211,40 @@ struct ExtendRange {
 	size_t sz;  // # of elements in SA range
 };
 
+/**
+ * One DP problem collected during the BWT-walk phase of extendSeedsCollect.
+ * Contains everything needed by extendSeedsAlign to run initRef + align
+ * without touching the BWT index again.
+ * While redudant, it helps performance highly when offloading to GPU cache.
+ */
+struct ExtendCandidate {
+	bool           fw;
+	TIndexOffU     tidx;      // reference sequence index
+	TIndexOffU     toff;      // offset within reference sequence
+	TIndexOffU     tlen;      // length of reference sequence
+	int64_t        refoff;    // ref offset implied by seed (no gaps)
+	DPRect         rect;      // DP bounding rectangle
+	size_t         nwindow;   // left-shift of seed within rect
+	Coord          refcoord;  // seed coordinate (for seenDiags bookkeeping)
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+	// Pre-decoded filter inputs, filled during collect so the GPU kernel
+	// needs nothing but this struct. 
+	bool     lrm11_passed;
+	bool     lrm11_ready;  // false if initRef failed; kernel skips this slot
+	uint16_t rflen;
+	uint16_t nrow;
+	int8_t   gaps[4];
+	uint8_t  profbuf[SSEData<false,ALN_MAX_ROWS,ALN_MAX_COLS>::get_nsses(ALN_MAX_ROWS)];
+	char     rf[ALN_MAX_COLS];
+#endif
+};
+
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+// Run EEU8_alignNucleotidesLRM11Scalar on a pre-filled ExtendCandidate.
+// Called from the offload kernel; takes only the candidate's embedded buffers.
+bool lrm11_filter_cand(const ExtendCandidate& cand, TAlScore minsc);
+#endif
+
 class SwDriver {
 
 public:
@@ -284,6 +318,64 @@ public:
 		AlnSinkWrap* mhs,            // HitSink for multiseed-style aligner
 		bool reportImmediately,      // whether to report hits immediately to mhs
 		bool& exhaustive);
+
+	/**
+	 * Phase 1 of the split extendSeeds pipeline.
+	 * Walks the BWT, resolves reference offsets, frames DP rectangles, and
+	 * collects surviving candidates into `cands`.
+	 * Returns EXTEND_PERFECT_SCORE early if minsc == perfectScore.
+	 */
+	int extendSeedsCollect(
+		const Ebwt& ebwtFw,
+		const BitPairReference& ref,
+		SwAligner& swa,
+		const Scoring& sc,
+		const int seedmms,
+		const int seedlen,
+		const int seedival,
+		const TAlScore minsc,
+		const int nceil,
+		const size_t maxhalf,
+		PerReadMetrics& prm,
+		EList<ExtendCandidate>& cands
+		);
+
+	/**
+	 * Phase 2 of the split extendSeeds pipeline.
+	 * For each candidate collected by extendSeedsCollect, runs initRef +
+	 * align + nextAlignment + report.  `swa` must already have initRead
+	 * called on it.
+	 * Returns EXTEND_POLICY_FULFILLED if a reporting limit is hit, or
+	 * EXTEND_EXHAUSTED_CANDIDATES when all candidates are processed.
+	 */
+	int extendSeedsAlign(
+		EList<ExtendCandidate>& cands,
+		const BitPairReference& ref,
+		SwAligner& swa,
+		const Scoring& sc,
+		const int seedmms,
+		const int seedlen,
+		const int seedival,
+		const TAlScore minsc,
+		const bool enable8,
+		PerReadMetrics& prm,
+		AlnSinkWrap* msink,
+		bool reportImmediately,
+		bool& exhaustive);
+
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+	/**
+	 * Phase 1b: LRM11Scalar pre-filter (scalar only).
+	 * For each candidate, calls initRef + buildQueryProfile + filterLRM11.
+	 * Sets cand.lrm11_passed; extendSeedsAlign skips candidates where it is false.
+	 */
+	void extendSeedsLRFilter(
+		EList<ExtendCandidate>& cands,
+		const BitPairReference& ref,
+		SwAligner& swa,
+		const TAlScore minsc,
+		const bool enable8);
+#endif
 
 #ifdef SUPPORT_PAIRED
 // NOTE: Unsupported, likely does not work

--- a/aligner_swsse_ee_u8.cpp
+++ b/aligner_swsse_ee_u8.cpp
@@ -60,6 +60,7 @@
 #ifndef SWSSE_INLINE_ONLY
 
 #include "aligner_sw.h"
+#include "aligner_sw_driver.h"
 
 #else
 
@@ -1722,6 +1723,57 @@ bool SwAligner::alignEnd2EndSseU8(
 	best = score;
 	return !btncand_.empty();
 }
+
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+bool SwAligner::filterLRM11(TAlScore minsc)
+{
+	assert(initedRef() && initedRead());
+	// EEU8_alignNucleotidesLRM11Scalar is compiled for MAX_ITER=151 only.
+	// For other read lengths the profbuf layout doesn't match — pass them through.
+	if(dpRows() != 151) return true;
+	buildQueryProfileEnd2EndSseU8(fw_);
+	auto& d = fw_ ? sseU8fw_ : sseU8rc_;
+	assert(!d.profbuf_.empty());
+	EEU8_TCScore lrmax = EEU8_alignNucleotidesLRM11Scalar<uint16_t>(
+		reinterpret_cast<const uint8_t*>(d.profbuf_.ptr()),
+		rf_, (uint16_t)rflen_,
+		dpRows(),
+		sc_->refGapOpen(), sc_->refGapExtend(),
+		sc_->readGapOpen(), sc_->readGapExtend());
+	TAlScore score = (TAlScore)(lrmax - 0xff);
+	return score >= minsc;
+}
+
+void SwAligner::fillCandBuffers(ExtendCandidate& cand)
+{
+	assert(initedRef() && initedRead());
+	buildQueryProfileEnd2EndSseU8(fw_);
+	const auto& d = fw_ ? sseU8fw_ : sseU8rc_;
+	assert(!d.profbuf_.empty());
+	memcpy(cand.profbuf, reinterpret_cast<const uint8_t*>(d.profbuf_.ptr()), sizeof(cand.profbuf));
+	memcpy(cand.rf, rf_, (size_t)rflen_);
+	cand.rflen   = (uint16_t)rflen_;
+	cand.nrow    = (uint16_t)dpRows();
+	cand.gaps[0] = (int8_t)sc_->refGapOpen();
+	cand.gaps[1] = (int8_t)sc_->refGapExtend();
+	cand.gaps[2] = (int8_t)sc_->readGapOpen();
+	cand.gaps[3] = (int8_t)sc_->readGapExtend();
+}
+
+#ifdef OMPGPU
+#pragma omp declare target
+#endif
+bool lrm11_filter_cand(const ExtendCandidate& cand, TAlScore minsc)
+{
+	EEU8_TCScore lrmax = EEU8_alignNucleotidesLRM11Scalar<uint16_t>(
+		cand.profbuf, cand.rf, cand.rflen, cand.nrow,
+		cand.gaps[0], cand.gaps[1], cand.gaps[2], cand.gaps[3]);
+	return (TAlScore)(lrmax - 0xff) >= minsc;
+}
+#ifdef OMPGPU
+#pragma omp end declare target
+#endif
+#endif
 
 #define MOVE_VEC_PTR_UP(vec, rowvec, rowelt) { \
 	if(rowvec == 0) { \

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -2275,6 +2275,7 @@ public:
 
 	SwDriverBT2 sd;
 	RandomSource rnd;
+	EList<ExtendCandidate> extend_cands; // filled by extendSeedsCollect, consumed by extendSeedsAlign
 
 };
 
@@ -2803,11 +2804,11 @@ static void multiseedSearchWorker() {
 		 	mate_allocs.ensure_spare();
 #endif
 
+		   	// Phase 1: BWT walk — resolve SA offsets to ref coordinates, frame DP rects.
+		   	// Serial within each mate's SwDriver (gws_ state), parallel across mates.
 		   	// we can do all of the "mates" in parallel
 #pragma omp parallel for default(shared)
 			for (uint32_t nb=0; nb<batch_parallel_tasks; nb++) {
-			   // These objects are really just work areas
-			   // Could have just created them here, but this way we minimize mallocs
 			   bcWorkerObjs& bcobj = g_bcobjs[nb];
 			   SwAligner &sw = bcobj.sw;
 
@@ -2815,68 +2816,159 @@ static void multiseedSearchWorker() {
 				const uint32_t mate = nb*reads_per_batch + ib;
 				if (mate_idx[mate]>=0 ) { // !done[mate]
 					msWorkerObjs& msobj = g_msobjs[mate];
-					AlnSinkWrapOne& msinkwrap = g_msinkwrap[mate]; 
-					const uint16_t interval = intervals[mate];
+					AlnSinkWrapOne& msinkwrap = g_msinkwrap[mate];
 					Read& rd = *rds[mate];
 					const size_t rdlen = rd.length();
-					// Initialize the aligner with a new read
 					sw.reset();
 					if (!sw.initRead(
-						rd.patFw,  // fw version of query
-						rd.patRc,  // rc version of query
-						rd.qual,   // fw version of qualities
-						rd.qualRev,// rc version of qualities
-						rdlen,     // off of last char (excl) in 'rd' to consider
-						msconsts->sc)) {     // scoring scheme
-								// Something went terribly wrong (likely read too long)
-								// Bail out
-								mate_idx[mate] = MATE_DONE;
+						rd.patFw,  rd.patRc,
+						rd.qual,   rd.qualRev,
+						rdlen,     msconsts->sc)) {
+						mate_idx[mate] = MATE_DONE;
 					} else {
-						const SeedResults& sh = psrs->getSR(mate);
-
-
-								// Unpaired dynamic programming driver
-								int ret = msobj.sd.extendSeeds(
-										sh,             // seed hits
-										msconsts->ebwtFw,         // bowtie index
-										msconsts->ref,            // packed reference strings
-										sw,                       // dynamic prog aligner
-										msconsts->sc,             // scoring scheme
-										multiseedMms,   // # mms allowed in a seed
-										multiseedLen,   // length of a seed
-										interval,       // interval between seeds
-										minsc[mate],    // minimum score for valid
-										nceil[mate],    // N ceil for anchor
-										msconsts->maxHalf,        // max width on one DP side
-										msconsts->extend,       // extend seed hits
-										msconsts->doEnable8,        // use 8-bit SSE where possible
-										msinkwrap.prm,  // per-read metrics
-										&msinkwrap,     // for organizing hits
-										true,           // report hits once found
-										exhaustive[mate]);
-								assert_gt(ret, 0);
-								if ((ret == EXTEND_EXHAUSTED_CANDIDATES) ||
-								     (ret == EXTEND_EXCEEDED_SOFT_LIMIT) ||
-                                                                     (ret == EXTEND_POLICY_FULFILLED)) {
-									// Not done yet
-									
-									// We don't necessarily have to continue investigating both
-									// mates.  We continue on a mate only if its average
-									// interval length is high (> 1000)
-									if(psrs->getSR(mate).averageHitsPerSeed() < seedBoostThresh) {
-										mate_idx[mate] = MATE_DONE;
-									} else if(msinkwrap.state().doneWithMate(true)) {
-										mate_idx[mate] = MATE_DONE;
-									}
-								} else {
-									mate_idx[mate] = MATE_DONE;
-								}
-
-					} // if initRead
-				} // if mate done
+						int ret = msobj.sd.extendSeedsCollect(
+							msconsts->ebwtFw,
+							msconsts->ref,
+							sw,
+							msconsts->sc,
+							multiseedMms,
+							multiseedLen,
+							intervals[mate],
+							minsc[mate],
+							nceil[mate],
+							msconsts->maxHalf,
+							msinkwrap.prm,
+							msobj.extend_cands
+							);
+						if (ret == EXTEND_PERFECT_SCORE) {
+							mate_idx[mate] = MATE_DONE;
+						}
+					}
+				} // if mate active
 			   } // for ib
 			} // for nb
-		   tmr.next("extendSeeds");
+		   tmr.next("extendSeeds_bwtwalk");
+
+		   // always call ensure_spare from main CPU thread
+#ifdef USE_CUSTOM_ALLOCS
+		   mate_allocs.ensure_spare();
+#endif
+
+		   	// Phase 1b: LRM11Scalar pre-filter — offload kernel over all candidates.
+		   	// profbuf and rf were decoded per-candidate during collect (extendSeeds_bwtwalk).
+		   	// All data lives in USM heap; no copies or data movement needed.
+#if defined(PRE_LR_SCALAR) && defined(SSE_SCALAR)
+		   	{
+		   		// Flatten all candidates across all mates into parallel arrays.
+		   		// Raw pointers let the offload kernel access candidates without
+		   		// going through EList::operator[], which isn't GPU-compiled.
+		   		// With -fopenmp-force-usm all heap is USM; no copies needed.
+		   		EList<ExtendCandidate*> cand_ptrs;
+		   		EList<TAlScore>         cand_minsc;
+		   		for (uint32_t mate = 0; mate < num_parallel_tasks; mate++) {
+		   			if (mate_idx[mate] < 0) continue;
+		   			EList<ExtendCandidate>& cands = g_msobjs[mate].extend_cands;
+		   			for (uint32_t ci = 0; ci < (uint32_t)cands.size(); ci++) {
+		   				cand_ptrs.push_back(&cands[ci]);
+		   				cand_minsc.push_back(minsc[mate]);
+		   			}
+		   		}
+		   		const uint32_t      nslots    = (uint32_t)cand_ptrs.size();
+		   		ExtendCandidate**   ptrs      = cand_ptrs.ptr();
+		   		const TAlScore*     minscs    = cand_minsc.ptr();
+
+		   		fprintf(stderr, "[lrfilter iter=%lu] nslots=%u\n", (unsigned long)repcnt, nslots);
+
+		   		// Divide candidates into npar blocks, each processed by one team.
+		   		static constexpr uint32_t LRFILTER_NPAR = 16384;
+		   		const uint32_t npar   = std::min(nslots, LRFILTER_NPAR);
+		   		const uint32_t elp_pp = (nslots + npar - 1) / npar;
+
+#ifdef OMPGPU
+#pragma omp target teams distribute num_teams(npar)
+		   		for (uint32_t p = 0; p < npar; p++) {
+		   			const uint32_t iend = std::min((p + 1) * elp_pp, nslots);
+#pragma omp parallel for
+		   			for (uint32_t si = p * elp_pp; si < iend; si++) {
+#else
+#pragma omp parallel for schedule(static) default(shared)
+		   		for (uint32_t si = 0; si < nslots; si++) {
+		   		{
+#endif
+		   			ExtendCandidate& cand = *ptrs[si];
+		   			if (!cand.lrm11_ready) { cand.lrm11_passed = true; } // pass-through: not filterable
+		   			else { cand.lrm11_passed = lrm11_filter_cand(cand, minscs[si]); }
+#ifdef OMPGPU
+		   			} // parallel for si
+		   		} // teams distribute p
+#else
+		   		} // dummy scope
+		   		} // parallel for si
+#endif
+		   	}
+		   tmr.next("extendSeeds_lrfilter");
+		   // always call ensure_spare from main CPU thread
+#ifdef USE_CUSTOM_ALLOCS
+		   mate_allocs.ensure_spare();
+#endif
+#endif // PRE_LR_SCALAR && SSE_SCALAR
+
+
+		   	// Phase 2: DP + backtrace — run SSE Smith-Waterman on passing candidates.
+		   	// Each mate's candidates are independent; parallel across mates.
+#pragma omp parallel for default(shared)
+			for (uint32_t nb=0; nb<batch_parallel_tasks; nb++) {
+			   bcWorkerObjs& bcobj = g_bcobjs[nb];
+			   SwAligner &sw = bcobj.sw;
+
+			   for (uint16_t ib=0; ib<reads_per_batch; ib++) {
+				const uint32_t mate = nb*reads_per_batch + ib;
+				if (mate_idx[mate]>=0 ) { // !done[mate]
+					msWorkerObjs& msobj = g_msobjs[mate];
+					AlnSinkWrapOne& msinkwrap = g_msinkwrap[mate];
+					Read& rd = *rds[mate];
+					const size_t rdlen = rd.length();
+					// Re-initialize sw for this mate: initRead state is per-worker,
+					// but sw is shared and was last set for whichever mate ran last
+					// in Phase 1 on this worker. Omit reset() to preserve pmat_
+					// layout, avoiding non-deterministic backtrace tie-breaking.
+					if(!sw.initRead(
+						rd.patFw,  rd.patRc,
+						rd.qual,   rd.qualRev,
+						rdlen,     msconsts->sc)) {
+						mate_idx[mate] = MATE_DONE;
+						continue;
+					}
+					int ret = msobj.sd.extendSeedsAlign(
+							msobj.extend_cands,
+							msconsts->ref,
+							sw,
+							msconsts->sc,
+							multiseedMms,
+							multiseedLen,
+							intervals[mate],
+							minsc[mate],
+							msconsts->doEnable8,
+							msinkwrap.prm,
+							&msinkwrap,
+							true,           // report hits once found
+							exhaustive[mate]);
+					assert_gt(ret, 0);
+					if ((ret == EXTEND_EXHAUSTED_CANDIDATES) ||
+					    (ret == EXTEND_EXCEEDED_SOFT_LIMIT)  ||
+					    (ret == EXTEND_POLICY_FULFILLED)) {
+						if(psrs->getSR(mate).averageHitsPerSeed() < seedBoostThresh) {
+							mate_idx[mate] = MATE_DONE;
+						} else if(msinkwrap.state().doneWithMate(true)) {
+							mate_idx[mate] = MATE_DONE;
+						}
+					} else {
+						mate_idx[mate] = MATE_DONE;
+					}
+				} // if mate active
+			   } // for ib
+			} // for nb
+		    tmr.next("extendSeeds_dp+backtrace");
 
 		   // always call ensure_spare from main CPU thread
 #ifdef USE_CUSTOM_ALLOCS

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -2821,31 +2821,38 @@ static void multiseedSearchWorker() {
 					AlnSinkWrapOne& msinkwrap = g_msinkwrap[mate];
 					Read& rd = *rds[mate];
 					const size_t rdlen = rd.length();
+					// Initialize the aligner with a new read
 					sw.reset();
 					if (!sw.initRead(
-						rd.patFw,  rd.patRc,
-						rd.qual,   rd.qualRev,
-						rdlen,     msconsts->sc)) {
-						mate_idx[mate] = MATE_DONE;
+						rd.patFw,  // fw version of query
+						rd.patRc,  // rc version of query
+						rd.qual,   // fw version of qualities
+						rd.qualRev,// rc version of qualities
+						rdlen,     // off of last char (excl) in 'rd' to consider
+						msconsts->sc)) {     // scoring scheme
+								// Something went terribly wrong (likely read too long)
+								// Bail out
+								mate_idx[mate] = MATE_DONE;
 					} else {
+						// Unpaired dynamic programming driver
 						int ret = msobj.sd.extendSeedsCollect(
-							msconsts->ebwtFw,
-							msconsts->ref,
-							sw,
-							msconsts->sc,
-							multiseedMms,
-							multiseedLen,
-							intervals[mate],
-							minsc[mate],
-							nceil[mate],
-							msconsts->maxHalf,
-							msinkwrap.prm,
-							msobj.extend_cands
+							msconsts->ebwtFw,         // bowtie index
+							msconsts->ref,            // packed reference strings
+							sw,                       // dynamic prog aligner
+							msconsts->sc,             // scoring scheme
+							multiseedMms,   // # mms allowed in a seed
+							multiseedLen,   // length of a seed
+							intervals[mate],// interval between seeds
+							minsc[mate],    // minimum score for valid
+							nceil[mate],    // N ceil for anchor
+							msconsts->maxHalf,        // max width on one DP side
+							msinkwrap.prm,  // per-read metrics
+							msobj.extend_cands // optional workspace to batch alignment jobs (for -DPRE_LR_FILTER)
 							);
 						if (ret == EXTEND_PERFECT_SCORE) {
 							mate_idx[mate] = MATE_DONE;
 						}
-					}
+					} // if initRead
 				} // if mate active
 			   } // for ib
 			} // for nb
@@ -2934,30 +2941,41 @@ static void multiseedSearchWorker() {
 					// in Phase 1 on this worker. Omit reset() to preserve pmat_
 					// layout, avoiding non-deterministic backtrace tie-breaking.
 					if(!sw.initRead(
-						rd.patFw,  rd.patRc,
-						rd.qual,   rd.qualRev,
-						rdlen,     msconsts->sc)) {
+						rd.patFw,  // fw version of query
+						rd.patRc,  // rc version of query
+						rd.qual,   // fw version of qualities
+						rd.qualRev,// rc version of qualities
+						rdlen,     // off of last char (excl) in 'rd' to consider
+						msconsts->sc)) {     // scoring scheme
+						// Something went terribly wrong (likely read too long)
+						// Bail out
 						mate_idx[mate] = MATE_DONE;
 						continue;
 					}
+					// Unpaired dynamic programming driver
 					int ret = msobj.sd.extendSeedsAlign(
-							msobj.extend_cands,
-							msconsts->ref,
-							sw,
-							msconsts->sc,
-							multiseedMms,
-							multiseedLen,
-							intervals[mate],
-							minsc[mate],
-							msconsts->doEnable8,
-							msinkwrap.prm,
-							&msinkwrap,
+							msobj.extend_cands,       // candidates from collect phase
+							msconsts->ref,            // packed reference strings
+							sw,                       // dynamic prog aligner
+							msconsts->sc,             // scoring scheme
+							multiseedMms,   // # mms allowed in a seed
+							multiseedLen,   // length of a seed
+							intervals[mate],// interval between seeds
+							minsc[mate],    // minimum score for valid
+							msconsts->doEnable8,      // use 8-bit SSE where possible
+							msinkwrap.prm,  // per-read metrics
+							&msinkwrap,     // for organizing hits
 							true,           // report hits once found
 							exhaustive[mate]);
 					assert_gt(ret, 0);
 					if ((ret == EXTEND_EXHAUSTED_CANDIDATES) ||
 					    (ret == EXTEND_EXCEEDED_SOFT_LIMIT)  ||
 					    (ret == EXTEND_POLICY_FULFILLED)) {
+						// Not done yet
+
+						// We don't necessarily have to continue investigating both
+						// mates.  We continue on a mate only if its average
+						// interval length is high (> 1000)
 						if(psrs->getSR(mate).averageHitsPerSeed() < seedBoostThresh) {
 							mate_idx[mate] = MATE_DONE;
 						} else if(msinkwrap.state().doneWithMate(true)) {

--- a/bt2_search.cpp
+++ b/bt2_search.cpp
@@ -2809,6 +2809,8 @@ static void multiseedSearchWorker() {
 		   	// we can do all of the "mates" in parallel
 #pragma omp parallel for default(shared)
 			for (uint32_t nb=0; nb<batch_parallel_tasks; nb++) {
+			   // These objects are really just work areas
+			   // Could have just created them here, but this way we minimize mallocs
 			   bcWorkerObjs& bcobj = g_bcobjs[nb];
 			   SwAligner &sw = bcobj.sw;
 
@@ -2877,10 +2879,10 @@ static void multiseedSearchWorker() {
 		   		ExtendCandidate**   ptrs      = cand_ptrs.ptr();
 		   		const TAlScore*     minscs    = cand_minsc.ptr();
 
-		   		fprintf(stderr, "[lrfilter iter=%lu] nslots=%u\n", (unsigned long)repcnt, nslots);
-
 		   		// Divide candidates into npar blocks, each processed by one team.
-		   		static constexpr uint32_t LRFILTER_NPAR = 16384;
+				// TODO: Since this is parallelization for GPU and not CPU
+				//       This variable may want to be different than omp
+		   		uint32_t LRFILTER_NPAR = batch_parallel_tasks;
 		   		const uint32_t npar   = std::min(nslots, LRFILTER_NPAR);
 		   		const uint32_t elp_pp = (nslots + npar - 1) / npar;
 
@@ -2906,13 +2908,12 @@ static void multiseedSearchWorker() {
 		   		} // parallel for si
 #endif
 		   	}
-		   tmr.next("extendSeeds_lrfilter");
+		    tmr.next("extendSeeds_lrfilter");
 		   // always call ensure_spare from main CPU thread
 #ifdef USE_CUSTOM_ALLOCS
 		   mate_allocs.ensure_spare();
 #endif
 #endif // PRE_LR_SCALAR && SSE_SCALAR
-
 
 		   	// Phase 2: DP + backtrace — run SSE Smith-Waterman on passing candidates.
 		   	// Each mate's candidates are independent; parallel across mates.
@@ -2968,7 +2969,7 @@ static void multiseedSearchWorker() {
 				} // if mate active
 			   } // for ib
 			} // for nb
-		    tmr.next("extendSeeds_dp+backtrace");
+		   tmr.next("extendSeeds_dp+backtrace");
 
 		   // always call ensure_spare from main CPU thread
 #ifdef USE_CUSTOM_ALLOCS


### PR DESCRIPTION
Seperate extendSeeds into steps

    BWT search/walk
    1b. Optional search for candidates
    DP Calculation (original kernel) + DP backtrace When 1b is used all DP Calculations will have candidates for a backtrace

Add extendCandidates struct.
A lot of extra outputs more Metric Collection
Works with scalar GPU offload, in a pure PRE_LR_SCALAR SSE_SCALAR with CPU/GPU OpenMP. Squashed batchAlignsCleanup branch...

PR a copy of https://github.com/IllusiveAldebaran/omp-bowtie2-prime/pull/4.